### PR TITLE
Backbone dedupe

### DIFF
--- a/grunt-tasks/browserify.js
+++ b/grunt-tasks/browserify.js
@@ -7,7 +7,12 @@ module.exports = {
       browserifyOptions: {
         debug: true, // to generate source-maps
         standalone: 'cartodb'
-      }
+      },
+      plugin: [
+        ['browserify-resolutions', '*']
+        // To be more specific we could use the following
+        // ['browserify-resolutions', ['backbone']]
+      ]
     }
   },
 
@@ -21,7 +26,12 @@ module.exports = {
       watch: '<%= config.doWatchify %>',
       browserifyOptions: {
         debug: true, // to generate source-maps
-      }
+      },
+      plugin: [
+        ['browserify-resolutions', '*']
+        // To be more specific we could use the following
+        // ['browserify-resolutions', ['backbone']]
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "browserify": "11.2.0",
+    "browserify-resolutions": "1.0.6",
     "grunt": "0.4.5",
     "grunt-browserify": "4.0.1",
     "grunt-contrib-clean": "0.7.0",

--- a/spec/dashboard-info-view.spec.js
+++ b/spec/dashboard-info-view.spec.js
@@ -1,11 +1,11 @@
 var moment = require('moment');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var DashboardInfoView = require('../src/dashboard-info-view');
 
 describe('../src/dashboard-info-view', function () {
   beforeEach(function () {
     var yesterday = moment().subtract(1, 'days').format(); // 2015-11-26T13:19:32+01:00
-    var model = new cdb.Backbone.Model({
+    var model = new Backbone.Model({
       title: 'Mapaza',
       description: 'Lorem ipsum...',
       updatedAt: yesterday

--- a/spec/dashboard-view.spec.js
+++ b/spec/dashboard-view.spec.js
@@ -1,10 +1,10 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var DashboardView = require('../src/dashboard-view');
 
 describe('dashboard-view', function () {
   beforeEach(function () {
     this.view = new DashboardView({
-      widgets: new cdb.Backbone.Collection(),
+      widgets: new Backbone.Collection(),
       dashboardInfoModel: new cdb.core.Model()
     });
   });

--- a/spec/windshaft/dashboard.spec.js
+++ b/spec/windshaft/dashboard.spec.js
@@ -1,6 +1,7 @@
 var $ = require('jquery');
 var _ = require('underscore');
 var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var Dashboard = require('../../src/windshaft/dashboard');
 var DashboardInstance = require('../../src/windshaft/dashboard-instance');
 var HistogramModel = require('../../src/widgets/histogram/model');
@@ -34,7 +35,7 @@ describe('windshaft/dashboard', function () {
         ]
       }
     });
-    this.widgets = new cdb.Backbone.Collection();
+    this.widgets = new Backbone.Collection();
 
     spyOn(this.dashboardInstance, 'getBaseURL').and.returnValue('baseURL');
     spyOn(this.dashboardInstance, 'getTiles').and.callFake(function (type) {
@@ -59,7 +60,7 @@ describe('windshaft/dashboard', function () {
       view_bounds_ne: []
     });
 
-    this.cartoDBLayerGroup = new cdb.Backbone.Model();
+    this.cartoDBLayerGroup = new Backbone.Model();
     this.cartoDBLayer1 = new cdb.geo.CartoDBLayer({ id: '12345-67890' });
     this.cartoDBLayer2 = new cdb.geo.CartoDBLayer({ id: '09876-54321' });
     this.torqueLayer = new cdb.geo.TorqueLayer();

--- a/spec/windshaft/public-dashboard-config.spec.js
+++ b/spec/windshaft/public-dashboard-config.spec.js
@@ -1,10 +1,11 @@
 var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var PublicDashboardConfig = require('../../src/windshaft/public-dashboard-config');
 var HistogramModel = require('../../src/widgets/histogram/model');
 
 describe('windshaft/public-dashboard-config', function () {
   beforeEach(function () {
-    this.widgets = new cdb.Backbone.Collection();
+    this.widgets = new Backbone.Collection();
 
     this.cartoDBLayer1 = new cdb.geo.CartoDBLayer({
       id: 'layer1',

--- a/src/widgets/histogram/model.js
+++ b/src/widgets/histogram/model.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var WidgetModel = require('../widget-model');
 
 module.exports = WidgetModel.extend({
@@ -34,7 +34,7 @@ module.exports = WidgetModel.extend({
 
   initialize: function (attrs, opts) {
     WidgetModel.prototype.initialize.apply(this, arguments);
-    this._data = new cdb.Backbone.Collection(this.get('data'));
+    this._data = new Backbone.Collection(this.get('data'));
 
     // BBox should only be included until after the first fetch, since we want to get the range of the full dataset
     this.once('change:data', function () {

--- a/src/widgets/list/model.js
+++ b/src/widgets/list/model.js
@@ -1,4 +1,4 @@
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var WidgetModel = require('../widget-model');
 
 module.exports = WidgetModel.extend({
@@ -8,7 +8,7 @@ module.exports = WidgetModel.extend({
   },
 
   initialize: function (attrs, opts) {
-    this._data = new cdb.Backbone.Collection(this.get('data'));
+    this._data = new Backbone.Collection(this.get('data'));
     WidgetModel.prototype.initialize.call(this, attrs, opts);
   },
 

--- a/src/windshaft/dashboard.js
+++ b/src/windshaft/dashboard.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var WindshaftFiltersCollection = require('./filters/collection');
 var WindshaftFiltersBoundingBoxFilter = require('./filters/bounding-box');
 var WindshaftDashboardInstance = require('./dashboard-instance');
@@ -8,7 +8,7 @@ var WindshaftDashboard = function (options) {
   var BOUNDING_BOX_FILTER_WAIT = 500;
 
   this.layerGroup = options.layerGroup;
-  this.layers = new cdb.Backbone.Collection(options.layers);
+  this.layers = new Backbone.Collection(options.layers);
   this.widgets = options.widgets;
   this.map = options.map;
   this.client = options.client;

--- a/src/windshaft/filters/category.js
+++ b/src/windshaft/filters/category.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var WindshaftFilterBase = require('./base');
 
 /**
@@ -12,8 +12,8 @@ module.exports = WindshaftFilterBase.extend({
   },
 
   initialize: function () {
-    this.rejectedCategories = new cdb.Backbone.Collection();
-    this.acceptedCategories = new cdb.Backbone.Collection();
+    this.rejectedCategories = new Backbone.Collection();
+    this.acceptedCategories = new Backbone.Collection();
     this._initBinds();
   },
 


### PR DESCRIPTION
This allows to `npm link cartodb.js` without duplicating `backbone` within the generated bundle when using browserify's `--debug` flag.