### PR TITLE
Don't show decimal numbers in the animation if the number is an integer

### DIFF
--- a/src/widgets/animate-values.js
+++ b/src/widgets/animate-values.js
@@ -13,7 +13,10 @@ module.exports = cdb.core.View.extend({
     var templateData = options.templateData || {};
     var debounceWait = options.debounceWait || 500;
 
+    var hasDecimals = (to % 1 === 0);
+
     var stepValue = function (i) {
+      i = hasDecimals ? Math.round(i) : i;
       var value = (_.isNaN(i) || i === undefined) ? (options.defaultValue || 0) : formatter(i);
       var data = _.extend({ value: value }, templateData);
       $el.text(template(data));
@@ -49,7 +52,10 @@ module.exports = cdb.core.View.extend({
     var formatter = options.formatter || d3.format('0,000');
     var templateData = options.templateData || {};
 
+    var hasDecimals = (to % 1 === 0);
+
     var stepValue = function (i) {
+      i = hasDecimals ? Math.round(i) : i;
       value = (_.isNaN(i) || i === undefined) ? (options.defaultValue || 0) : formatter(i);
       var data = _.extend({ value: value }, templateData);
       $el.text(template(data));
@@ -85,7 +91,10 @@ module.exports = cdb.core.View.extend({
     var formatter = options.formatter || d3.format('0,000');
     var templateData = options.templateData || {};
 
+    var hasDecimals = (to % 1 === 0);
+
     var stepValue = function (i) {
+      i = hasDecimals ? Math.round(i) : i;
       var value = (_.isNaN(i) || i === undefined) ? (options.defaultValue || 0) : formatter(i);
       var data = _.extend({ value: value }, templateData);
       $el.text(template(data));


### PR DESCRIPTION
Fixes #25 by rounding the middle numbers if the origin number is not a float.

![fix](https://cloud.githubusercontent.com/assets/4933/12017506/d170e79e-ad57-11e5-84f2-ba35b69a98d8.gif)
