### PR TITLE
Adds missing class in the histogram tooltips 

### DIFF
--- a/src/widgets/histogram/content.tpl
+++ b/src/widgets/histogram/content.tpl
@@ -12,7 +12,7 @@
   </dl>
 </div>
 <div class="CDB-Widget-content js-content">
-  <div class="CDB-Widget-tooltip js-tooltip"></div>
+  <div class="CDB-Widget-tooltip CDB-Widget-tooltip--light js-tooltip"></div>
   <div class="CDB-Widget-filter CDB-Widget-contentSpaced js-filter is-hidden">
     <p class="CDB-Widget-textSmaller CDB-Widget-textSmaller--bold CDB-Widget-textSmaller--upper js-val"></p>
     <div class="CDB-Widget-filterButtons">


### PR DESCRIPTION
This PR adds a missing class so the light tooltips appear correctly after this change: https://github.com/CartoDB/deep-insights.js/pull/70/files

/cc @xavijam 
