### PR TITLE
Bring back 'SELECTED' label 

### DIFF
--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -325,7 +325,7 @@ module.exports = WidgetContentView.extend({
   },
 
   _onChangeTotal: function () {
-    this._changeHeaderValue('.js-val', 'total', '');
+    this._changeHeaderValue('.js-val', 'total', 'SELECTED');
   },
 
   _onChangeMax: function () {


### PR DESCRIPTION
This PR fixes a possible bug introduced in this PR: https://github.com/CartoDB/deep-insights.js/pull/69/files#diff-073fbe94fcf07c28afc1f6287797a05dL328 

The issue is that the 'SELECTED' label after the number of elements selected by the histogram range is no longer appearing:

![screen shot 2016-01-20 at 19 18 10](https://cloud.githubusercontent.com/assets/4933/12458532/92c8533c-bfaa-11e5-91f7-2b792cff371e.png)

@piensaenpixel: I'm saying "possible" because I don't know if we removed it by mistake or not. Can you review this, please?