### PR TITLE
Allow override of the default sync settings

### DIFF
--- a/examples/populated-places-local.html
+++ b/examples/populated-places-local.html
@@ -82,19 +82,19 @@
             "type": "formula",
             "title": "Total population",
             "layer_id": "4d82e8df-f21b-4225-b776-61b1bdffde6c",
+            "suffix": " people",
             "options": {
               "column": "pop_max",
               "operation": "sum",
-              "suffix": " people"
             },
           }, {
             "type": "formula",
             "title": "# places",
             "layer_id": "4d82e8df-f21b-4225-b776-61b1bdffde6c",
+            "prefix": "$",
             "options": {
               "column": "pop_max",
               "operation": "count",
-              "prefix": "$"
             },
           }, {
             "type": "formula",

--- a/examples/populated-places.html
+++ b/examples/populated-places.html
@@ -32,10 +32,12 @@
           "widgets": [
             {
               "type": "formula",
-              "title": "Min population",
+              "title": "Min population (disabled sync)",
               "layer_id": "4d82e8df-f21b-4225-b776-61b1bdffde6c",
               "options": {
                 "column": "pop_max",
+                "sync_on_source_change": false,
+                "sync_on_bbox_change": false,
                 "operation": "min"
               }
             }, {
@@ -300,6 +302,9 @@
           .error(function(err) {
             console.error(err);
           });
+
+        console.info('first widget is disabled on start, run the following the dev console to enable it:',
+        'dashboard.widgets._widgetsCollection.at(0).update({sync_on_source_change: true, sync_on_bbox_change: true, title: "Min population"})')
       }
     </script>
   </body>

--- a/examples/populated-places.html
+++ b/examples/populated-places.html
@@ -36,7 +36,7 @@
               "layer_id": "4d82e8df-f21b-4225-b776-61b1bdffde6c",
               "options": {
                 "column": "pop_max",
-                "sync_on_source_change": false,
+                "sync_on_data_change": false,
                 "sync_on_bbox_change": false,
                 "operation": "min"
               }
@@ -304,7 +304,7 @@
           });
 
         console.info('first widget is disabled on start, run the following the dev console to enable it:',
-        'dashboard.widgets._widgetsCollection.at(0).update({sync_on_source_change: true, sync_on_bbox_change: true, title: "Min population"})')
+        'dashboard.widgets._widgetsCollection.at(0).update({sync_on_data_change: true, sync_on_bbox_change: true, title: "Min population"})')
       }
     </script>
   </body>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "backbone": "1.2.3",
-    "cartodb.js": "CartoDB/cartodb.js#27fa14b",
+    "cartodb.js": "CartoDB/cartodb.js#d2bb371",
     "d3": "3.5.8",
     "jquery": "2.1.4",
     "jstify": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "backbone": "1.2.3",
-    "cartodb.js": "CartoDB/cartodb.js#acc383a",
+    "cartodb.js": "CartoDB/cartodb.js#9dd4f0e",
     "d3": "3.5.8",
     "jquery": "2.1.4",
     "jstify": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "backbone": "1.2.3",
-    "cartodb.js": "CartoDB/cartodb.js#3920d2f",
+    "cartodb.js": "CartoDB/cartodb.js#2e9b0ea",
     "d3": "3.5.8",
     "jquery": "2.1.4",
     "jstify": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "backbone": "1.2.3",
-    "cartodb.js": "CartoDB/cartodb.js#6e53e53",
+    "cartodb.js": "CartoDB/cartodb.js#27fa14b",
     "d3": "3.5.8",
     "jquery": "2.1.4",
     "jstify": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "backbone": "1.2.3",
-    "cartodb.js": "CartoDB/cartodb.js#d2bb371",
+    "cartodb.js": "CartoDB/cartodb.js#a740f3d",
     "d3": "3.5.8",
     "jquery": "2.1.4",
     "jstify": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "backbone": "1.2.3",
-    "cartodb.js": "CartoDB/cartodb.js#a740f3d",
+    "cartodb.js": "CartoDB/cartodb.js#3920d2f",
     "d3": "3.5.8",
     "jquery": "2.1.4",
     "jstify": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "backbone": "1.2.3",
-    "cartodb.js": "CartoDB/cartodb.js#9dd4f0e",
+    "cartodb.js": "CartoDB/cartodb.js#de71057",
     "d3": "3.5.8",
     "jquery": "2.1.4",
     "jstify": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "backbone": "1.2.3",
-    "cartodb.js": "CartoDB/cartodb.js#2e9b0ea",
+    "cartodb.js": "CartoDB/cartodb.js#acc383a",
     "d3": "3.5.8",
     "jquery": "2.1.4",
     "jstify": "0.12.0",

--- a/spec/widgets-service.spec.js
+++ b/spec/widgets-service.spec.js
@@ -67,7 +67,7 @@ describe('widgets-service', function () {
 
       it('should enable dataview by default', function () {
         expect(this.widgetModel.dataviewModel.get('sync_on_bbox_change')).toBe(true);
-        expect(this.widgetModel.dataviewModel.get('sync_on_source_change')).toBe(true);
+        expect(this.widgetModel.dataviewModel.get('sync_on_data_change')).toBe(true);
         expect(this.widgetModel.dataviewModel.get('enabled')).toBe(true);
       });
     });
@@ -81,7 +81,7 @@ describe('widgets-service', function () {
           aggregation: 'avg',
           suffix: ' people',
           sync_on_bbox_change: false,
-          sync_on_source_change: false,
+          sync_on_data_change: false,
           enabled: false
         };
         this.widgetModel = this.widgetsService.createCategoryModel(attrs, this.vis.map.layers.first());
@@ -89,7 +89,7 @@ describe('widgets-service', function () {
 
       it('should take them into account', function () {
         expect(this.widgetModel.dataviewModel.get('sync_on_bbox_change')).toBe(false);
-        expect(this.widgetModel.dataviewModel.get('sync_on_source_change')).toBe(false);
+        expect(this.widgetModel.dataviewModel.get('sync_on_data_change')).toBe(false);
         expect(this.widgetModel.dataviewModel.get('enabled')).toBe(false);
       });
     });
@@ -155,7 +155,7 @@ describe('widgets-service', function () {
 
       it('should enable dataview by default', function () {
         expect(this.widgetModel.dataviewModel.get('sync_on_bbox_change')).toBe(true);
-        expect(this.widgetModel.dataviewModel.get('sync_on_source_change')).toBe(true);
+        expect(this.widgetModel.dataviewModel.get('sync_on_data_change')).toBe(true);
         expect(this.widgetModel.dataviewModel.get('enabled')).toBe(true);
       });
     });
@@ -230,7 +230,7 @@ describe('widgets-service', function () {
 
       it('should enable dataview by default', function () {
         expect(this.widgetModel.dataviewModel.get('sync_on_bbox_change')).toBe(true);
-        expect(this.widgetModel.dataviewModel.get('sync_on_source_change')).toBe(true);
+        expect(this.widgetModel.dataviewModel.get('sync_on_data_change')).toBe(true);
         expect(this.widgetModel.dataviewModel.get('enabled')).toBe(true);
       });
     });
@@ -300,7 +300,7 @@ describe('widgets-service', function () {
 
       it('should enable dataview by default', function () {
         expect(this.widgetModel.dataviewModel.get('sync_on_bbox_change')).toBe(true);
-        expect(this.widgetModel.dataviewModel.get('sync_on_source_change')).toBe(true);
+        expect(this.widgetModel.dataviewModel.get('sync_on_data_change')).toBe(true);
         expect(this.widgetModel.dataviewModel.get('enabled')).toBe(true);
       });
     });
@@ -366,7 +366,7 @@ describe('widgets-service', function () {
 
       it('should enable dataview by default', function () {
         expect(this.widgetModel.dataviewModel.get('sync_on_bbox_change')).toBe(true);
-        expect(this.widgetModel.dataviewModel.get('sync_on_source_change')).toBe(true);
+        expect(this.widgetModel.dataviewModel.get('sync_on_data_change')).toBe(true);
         expect(this.widgetModel.dataviewModel.get('enabled')).toBe(true);
       });
     });

--- a/spec/widgets-service.spec.js
+++ b/spec/widgets-service.spec.js
@@ -32,6 +32,7 @@ describe('widgets-service', function () {
           title: 'some_title',
           column: 'my_column',
           aggregation: 'avg',
+          prefix: '$',
           suffix: ' people'
         };
         this.widgetModel = this.widgetsService.createCategoryModel(attrs, this.vis.map.layers.first());
@@ -58,11 +59,11 @@ describe('widgets-service', function () {
       });
 
       it('should have a suffix text', function () {
-        expect(this.widgetModel.dataviewModel.get('suffix')).toEqual(' people');
+        expect(this.widgetModel.get('suffix')).toEqual(' people');
       });
 
-      it('should have a default prefix text', function () {
-        expect(this.widgetModel.dataviewModel.get('prefix')).toEqual('');
+      it('should have a prefix text', function () {
+        expect(this.widgetModel.get('prefix')).toEqual('$');
       });
 
       it('should enable dataview by default', function () {
@@ -195,7 +196,8 @@ describe('widgets-service', function () {
           title: 'my formula',
           column: 'a_column',
           operation: 'sum',
-          prefix: 'hello'
+          prefix: '$',
+          suffix: '¢'
         };
         this.widgetModel = this.widgetsService.createFormulaModel(attrs, this.vis.map.layers.first());
       });
@@ -221,11 +223,11 @@ describe('widgets-service', function () {
       });
 
       it('should have a default suffix text', function () {
-        expect(this.widgetModel.dataviewModel.get('suffix')).toEqual('');
+        expect(this.widgetModel.get('suffix')).toEqual('¢');
       });
 
       it('should have a prefix text', function () {
-        expect(this.widgetModel.dataviewModel.get('prefix')).toEqual('hello');
+        expect(this.widgetModel.get('prefix')).toEqual('$');
       });
 
       it('should enable dataview by default', function () {

--- a/spec/widgets-service.spec.js
+++ b/spec/widgets-service.spec.js
@@ -76,17 +76,19 @@ describe('widgets-service', function () {
 
     describe('fails when the input has no', function () {
       it('title', function () {
-        this.widgetModel = this.widgetsService.createCategoryModel({
-          column: 'my_column'
-        }, this.vis.map.layers.first());
-        expect(this.widgetModel).not.toBeDefined();
+        expect(function () {
+          this.widgetModel = this.widgetsService.createCategoryModel({
+            column: 'my_column'
+          }, this.vis.map.layers.first());
+        }).toThrowError();
       });
 
       it('column', function () {
-        this.widgetModel = this.widgetsService.createCategoryModel({
-          title: 'some_title'
-        }, this.vis.map.layers.first());
-        expect(this.widgetModel).not.toBeDefined();
+        expect(function () {
+          this.widgetModel = this.widgetsService.createCategoryModel({
+            title: 'some_title'
+          }, this.vis.map.layers.first());
+        }).toThrowError();
       });
     });
   });
@@ -134,17 +136,19 @@ describe('widgets-service', function () {
 
     describe('fails when the input has no', function () {
       it('title', function () {
-        this.widgetModel = this.widgetsService.createHistogramModel({
-          column: 'my_column'
-        }, this.vis.map.layers.first());
-        expect(this.widgetModel).not.toBeDefined();
+        expect(function () {
+          this.widgetModel = this.widgetsService.createHistogramModel({
+            column: 'my_column'
+          }, this.vis.map.layers.first());
+        }).toThrowError();
       });
 
       it('column', function () {
-        this.widgetModel = this.widgetsService.createHistogramModel({
-          title: 'some_title'
-        }, this.vis.map.layers.first());
-        expect(this.widgetModel).not.toBeDefined();
+        expect(function () {
+          this.widgetModel = this.widgetsService.createHistogramModel({
+            title: 'some_title'
+          }, this.vis.map.layers.first());
+        }).toThrowError();
       });
     });
   });
@@ -193,28 +197,31 @@ describe('widgets-service', function () {
 
     describe('fails when the input has no', function () {
       it('title', function () {
-        this.widgetModel = this.widgetsService.createFormulaModel({
-          id: 'abc-123',
-          column: 'my_column',
-          operation: 'sum'
-        }, this.vis.map.layers.first());
-        expect(this.widgetModel).not.toBeDefined();
+        expect(function () {
+          this.widgetModel = this.widgetsService.createFormulaModel({
+            id: 'abc-123',
+            column: 'my_column',
+            operation: 'sum'
+          }, this.vis.map.layers.first());
+        }).toThrowError();
       });
 
       it('column', function () {
-        this.widgetModel = this.widgetsService.createFormulaModel({
-          title: 'some_title',
-          operation: 'sum'
-        }, this.vis.map.layers.first());
-        expect(this.widgetModel).not.toBeDefined();
+        expect(function () {
+          this.widgetModel = this.widgetsService.createFormulaModel({
+            title: 'some_title',
+            operation: 'sum'
+          }, this.vis.map.layers.first());
+        }).toThrowError();
       });
 
       it('operation', function () {
-        this.widgetModel = this.widgetsService.createFormulaModel({
-          title: 'some_title',
-          column: 'my_column'
-        }, this.vis.map.layers.first());
-        expect(this.widgetModel).not.toBeDefined();
+        expect(function () {
+          this.widgetModel = this.widgetsService.createFormulaModel({
+            title: 'some_title',
+            column: 'my_column'
+          }, this.vis.map.layers.first());
+        }).toThrowError();
       });
     });
   });
@@ -254,27 +261,30 @@ describe('widgets-service', function () {
 
     describe('fails when the input has no', function () {
       it('title', function () {
-        this.widgetModel = this.widgetsService.createListModel({
-          columns: ['a', 'b'],
-          columns_title: ['first', '2nd']
-        }, this.vis.map.layers.first());
-        expect(this.widgetModel).not.toBeDefined();
+        expect(function () {
+          this.widgetModel = this.widgetsService.createListModel({
+            columns: ['a', 'b'],
+            columns_title: ['first', '2nd']
+          }, this.vis.map.layers.first());
+        }).toThrowError();
       });
 
       it('columns', function () {
-        this.widgetModel = this.widgetsService.createListModel({
-          title: 'my list',
-          columns_title: ['first', '2nd']
-        }, this.vis.map.layers.first());
-        expect(this.widgetModel).not.toBeDefined();
+        expect(function () {
+          this.widgetModel = this.widgetsService.createListModel({
+            title: 'my list',
+            columns_title: ['first', '2nd']
+          }, this.vis.map.layers.first());
+        }).toThrowError();
       });
 
       it('columns_title', function () {
-        this.widgetModel = this.widgetsService.createListModel({
-          title: 'my list',
-          columns: ['a', 'b']
-        }, this.vis.map.layers.first());
-        expect(this.widgetModel).not.toBeDefined();
+        expect(function () {
+          this.widgetModel = this.widgetsService.createListModel({
+            title: 'my list',
+            columns: ['a', 'b']
+          }, this.vis.map.layers.first());
+        }).toThrowError();
       });
     });
   });
@@ -312,10 +322,11 @@ describe('widgets-service', function () {
 
   describe('fails when the input has no', function () {
     it('column', function () {
-      this.widgetModel = this.widgetsService.createTimeSeriesModel({
-        title: 'some_title'
-      }, this.vis.map.layers.first());
-      expect(this.widgetModel).not.toBeDefined();
+      expect(function () {
+        this.widgetModel = this.widgetsService.createTimeSeriesModel({
+          title: 'some_title'
+        }, this.vis.map.layers.first());
+      }).toThrowError();
     });
   });
 });

--- a/spec/widgets-service.spec.js
+++ b/spec/widgets-service.spec.js
@@ -149,7 +149,7 @@ describe('widgets-service', function () {
         expect(this.widgetModel.dataviewModel.get('column')).toEqual('a_column');
       });
 
-      it('should set default bins', function () {
+      it('should set bins', function () {
         expect(this.widgetModel.dataviewModel.get('bins')).toEqual(20);
       });
 

--- a/spec/widgets-service.spec.js
+++ b/spec/widgets-service.spec.js
@@ -64,6 +64,34 @@ describe('widgets-service', function () {
       it('should have a default prefix text', function () {
         expect(this.widgetModel.dataviewModel.get('prefix')).toEqual('');
       });
+
+      it('should enable dataview by default', function () {
+        expect(this.widgetModel.dataviewModel.get('sync_on_bbox_change')).toBe(true);
+        expect(this.widgetModel.dataviewModel.get('sync_on_source_change')).toBe(true);
+        expect(this.widgetModel.dataviewModel.get('enabled')).toBe(true);
+      });
+    });
+
+    describe('when given custom sync options', function () {
+      beforeEach(function () {
+        var attrs = {
+          id: 'abc-123',
+          title: 'some_title',
+          column: 'my_column',
+          aggregation: 'avg',
+          suffix: ' people',
+          sync_on_bbox_change: false,
+          sync_on_source_change: false,
+          enabled: false
+        };
+        this.widgetModel = this.widgetsService.createCategoryModel(attrs, this.vis.map.layers.first());
+      });
+
+      it('should take them into account', function () {
+        expect(this.widgetModel.dataviewModel.get('sync_on_bbox_change')).toBe(false);
+        expect(this.widgetModel.dataviewModel.get('sync_on_source_change')).toBe(false);
+        expect(this.widgetModel.dataviewModel.get('enabled')).toBe(false);
+      });
     });
 
     it('when no aggregation specified should use the default operation', function () {
@@ -123,6 +151,12 @@ describe('widgets-service', function () {
 
       it('should set default bins', function () {
         expect(this.widgetModel.dataviewModel.get('bins')).toEqual(20);
+      });
+
+      it('should enable dataview by default', function () {
+        expect(this.widgetModel.dataviewModel.get('sync_on_bbox_change')).toBe(true);
+        expect(this.widgetModel.dataviewModel.get('sync_on_source_change')).toBe(true);
+        expect(this.widgetModel.dataviewModel.get('enabled')).toBe(true);
       });
     });
 
@@ -193,6 +227,12 @@ describe('widgets-service', function () {
       it('should have a prefix text', function () {
         expect(this.widgetModel.dataviewModel.get('prefix')).toEqual('hello');
       });
+
+      it('should enable dataview by default', function () {
+        expect(this.widgetModel.dataviewModel.get('sync_on_bbox_change')).toBe(true);
+        expect(this.widgetModel.dataviewModel.get('sync_on_source_change')).toBe(true);
+        expect(this.widgetModel.dataviewModel.get('enabled')).toBe(true);
+      });
     });
 
     describe('fails when the input has no', function () {
@@ -257,6 +297,12 @@ describe('widgets-service', function () {
       it('should set columns title', function () {
         expect(this.widgetModel.get('columns_title')).toEqual(['first', '2nd']);
       });
+
+      it('should enable dataview by default', function () {
+        expect(this.widgetModel.dataviewModel.get('sync_on_bbox_change')).toBe(true);
+        expect(this.widgetModel.dataviewModel.get('sync_on_source_change')).toBe(true);
+        expect(this.widgetModel.dataviewModel.get('enabled')).toBe(true);
+      });
     });
 
     describe('fails when the input has no', function () {
@@ -316,6 +362,12 @@ describe('widgets-service', function () {
 
       it('should be backed up by a histogram dataview model', function () {
         expect(this.widgetModel.dataviewModel.get('type')).toEqual('histogram');
+      });
+
+      it('should enable dataview by default', function () {
+        expect(this.widgetModel.dataviewModel.get('sync_on_bbox_change')).toBe(true);
+        expect(this.widgetModel.dataviewModel.get('sync_on_source_change')).toBe(true);
+        expect(this.widgetModel.dataviewModel.get('enabled')).toBe(true);
       });
     });
   });

--- a/spec/widgets/category/category-widget-model.spec.js
+++ b/spec/widgets/category/category-widget-model.spec.js
@@ -4,7 +4,9 @@ var specHelper = require('../../spec-helper');
 describe('widgets/category/category-widget-model', function () {
   beforeEach(function () {
     var vis = specHelper.createDefaultVis();
-    this.dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {});
+    this.dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {
+      column: 'col'
+    });
     this.widgetModel = new CategoryWidgetModel({}, {
       dataviewModel: this.dataviewModel
     });

--- a/spec/widgets/category/content-view.spec.js
+++ b/spec/widgets/category/content-view.spec.js
@@ -5,7 +5,9 @@ var CategoryContentView = require('../../../src/widgets/category/content-view');
 describe('widgets/category/content-view', function () {
   beforeEach(function () {
     var vis = specHelper.createDefaultVis();
-    this.dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {});
+    this.dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {
+      column: 'col'
+    });
     this.model = new CategoryWidgetModel({
       title: 'Categories of something'
     }, {

--- a/spec/widgets/category/items-view.spec.js
+++ b/spec/widgets/category/items-view.spec.js
@@ -5,7 +5,9 @@ var ItemsView = require('../../../src/widgets/category/list/items-view');
 describe('widgets/category/items-view', function () {
   beforeEach(function () {
     var vis = specHelper.createDefaultVis();
-    this.dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {});
+    this.dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {
+      column: 'col'
+    });
     this.widgetModel = new CategoryWidgetModel({}, {
       dataviewModel: this.dataviewModel
     });

--- a/spec/widgets/category/options-view.spec.js
+++ b/spec/widgets/category/options-view.spec.js
@@ -5,7 +5,9 @@ var OptionsView = require('../../../src/widgets/category/options/options-view');
 describe('widgets/category/options-view', function () {
   beforeEach(function () {
     var vis = specHelper.createDefaultVis();
-    this.dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {});
+    this.dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {
+      column: 'col'
+    });
     this.widgetModel = new CategoryWidgetModel({}, {
       dataviewModel: this.dataviewModel
     });

--- a/spec/widgets/category/search-title-view.spec.js
+++ b/spec/widgets/category/search-title-view.spec.js
@@ -5,7 +5,9 @@ var SearchTitleView = require('../../../src/widgets/category/title/search-title-
 describe('widgets/category/search-title-view', function () {
   beforeEach(function () {
     var vis = specHelper.createDefaultVis();
-    this.dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {});
+    this.dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {
+      column: 'col'
+    });
     this.widgetModel = new CategoryWidgetModel({}, {
       dataviewModel: this.dataviewModel
     });

--- a/spec/widgets/category/stats-view.spec.js
+++ b/spec/widgets/category/stats-view.spec.js
@@ -5,7 +5,9 @@ var StatsView = require('../../../src/widgets/category/stats/stats-view');
 describe('widgets/category/stats-view', function () {
   beforeEach(function () {
     var vis = specHelper.createDefaultVis();
-    this.dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {});
+    this.dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {
+      column: 'col'
+    });
     this.widgetModel = new CategoryWidgetModel({}, {
       dataviewModel: this.dataviewModel
     });

--- a/spec/widgets/formula/content-view.spec.js
+++ b/spec/widgets/formula/content-view.spec.js
@@ -7,7 +7,10 @@ describe('widgets/formula/content-view', function () {
   beforeEach(function () {
     AnimateValues.prototype.animateValue = function () {};
     var vis = specHelper.createDefaultVis();
-    this.dataviewModel = vis.dataviews.createFormulaModel(vis.map.layers.first(), {});
+    this.dataviewModel = vis.dataviews.createFormulaModel(vis.map.layers.first(), {
+      column: 'col',
+      operation: 'avg'
+    });
     this.model = new WidgetModel({
       title: 'Max population'
     }, {

--- a/spec/widgets/histogram/content-view.spec.js
+++ b/spec/widgets/histogram/content-view.spec.js
@@ -8,9 +8,7 @@ describe('widgets/histogram/content-view', function () {
     var vis = specHelper.createDefaultVis();
     this.dataviewModel = vis.dataviews.createHistogramModel(vis.map.layers.first(), {
       id: 'widget_3',
-      options: {
-        columns: ['cartodb_id', 'title']
-      }
+      column: 'col'
     });
 
     this.widgetModel = new HistogramWidgetModel({

--- a/spec/widgets/histogram/histogram-widget-model.spec.js
+++ b/spec/widgets/histogram/histogram-widget-model.spec.js
@@ -5,6 +5,7 @@ describe('widgets/histogram/histogram-widget-model', function () {
   beforeEach(function () {
     var vis = specHelper.createDefaultVis();
     this.dataviewModel = vis.dataviews.createHistogramModel(vis.map.layers.first(), {
+      column: 'col'
     });
     this.widgetModel = new HistogramWidgetModel({}, {
       dataviewModel: this.dataviewModel

--- a/spec/widgets/list/content-view.spec.js
+++ b/spec/widgets/list/content-view.spec.js
@@ -8,7 +8,6 @@ describe('widgets/list/content-view', function () {
     var vis = specHelper.createDefaultVis();
     this.dataviewModel = vis.dataviews.createListModel(vis.map.layers.first(), {
       id: 'widget_3',
-      title: 'Howdy',
       columns: ['cartodb_id', 'title']
     });
     this.widgetModel = new WidgetModel({}, {

--- a/spec/widgets/time-series/content-view.spec.js
+++ b/spec/widgets/time-series/content-view.spec.js
@@ -5,7 +5,9 @@ var WidgetModel = require('../../../src/widgets/widget-model');
 describe('widgets/time-series/content-view', function () {
   beforeEach(function () {
     var vis = specHelper.createDefaultVis();
-    this.dataviewModel = vis.dataviews.createHistogramModel(vis.map.layers.first(), {});
+    this.dataviewModel = vis.dataviews.createHistogramModel(vis.map.layers.first(), {
+      column: 'col'
+    });
     this.dataviewModel.sync = function (method, dataviewModel, options) {
       this.options = options;
     }.bind(this);

--- a/spec/widgets/time-series/torque-content-view.spec.js
+++ b/spec/widgets/time-series/torque-content-view.spec.js
@@ -5,7 +5,9 @@ var WidgetModel = require('../../../src/widgets/widget-model');
 describe('widgets/time-series/torque-content-view', function () {
   beforeEach(function () {
     var vis = specHelper.createDefaultVis();
-    this.dataviewModel = vis.dataviews.createHistogramModel(vis.map.layers.first(), {});
+    this.dataviewModel = vis.dataviews.createHistogramModel(vis.map.layers.first(), {
+      column: 'col'
+    });
     this.dataviewModel.sync = function (method, model, options) {
       this.options = options;
     }.bind(this);

--- a/spec/widgets/time-series/torque-time-slider-view.spec.js
+++ b/spec/widgets/time-series/torque-time-slider-view.spec.js
@@ -6,6 +6,7 @@ describe('widgets/time-series/torque-time-slider-view', function () {
   beforeEach(function () {
     var vis = specHelper.createDefaultVis();
     this.dataviewModel = vis.dataviews.createHistogramModel(vis.map.layers.first(), {
+      column: 'dates',
       bins: 256
     });
     this.torqueLayerModel = new cdb.geo.TorqueLayer({

--- a/spec/widgets/widget-model.spec.js
+++ b/spec/widgets/widget-model.spec.js
@@ -1,10 +1,15 @@
-var cdb = require('cartodb.js');
+var specHelper = require('../spec-helper');
 var WidgetModel = require('../../src/widgets/widget-model');
 
 describe('widgets/widget-model', function () {
   beforeEach(function () {
-    var dataviewModel = new cdb.core.Model();
-    dataviewModel.remove = jasmine.createSpy('dataviewModel.remove');
+    var vis = specHelper.createDefaultVis();
+    // Use a category dataview as example
+    var dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {
+      column: 'col'
+    });
+    dataviewModel.remove = spyOn(dataviewModel, 'remove');
+
     this.model = new WidgetModel(null, {
       dataviewModel: dataviewModel
     });
@@ -13,9 +18,7 @@ describe('widgets/widget-model', function () {
   describe('.update', function () {
     beforeEach(function () {
       this.widgetChangeSpy = jasmine.createSpy('widgetModel change');
-      this.dataviewModelChangeSpy = jasmine.createSpy('dataviewModel change');
       this.model.on('change', this.widgetChangeSpy);
-      this.model.dataviewModel.on('change', this.dataviewModelChangeSpy);
     });
 
     describe('when given empty object', function () {
@@ -30,7 +33,7 @@ describe('widgets/widget-model', function () {
 
       it('should not change anything', function () {
         expect(this.widgetChangeSpy).not.toHaveBeenCalled();
-        expect(this.dataviewModelChangeSpy).not.toHaveBeenCalled();
+        expect(this.model.dataviewModel.changedAttributes()).toBe(false);
       });
     });
 
@@ -42,7 +45,7 @@ describe('widgets/widget-model', function () {
         this.result = this.model.update({
           title: 'new title',
           column: 'col',
-          operation: 'count',
+          aggregation: 'count',
           invalid: 'attr, should not be set'
         });
       });
@@ -68,21 +71,20 @@ describe('widgets/widget-model', function () {
       });
 
       it('should not update dataviewModel', function () {
-        expect(this.dataviewModelChangeSpy).not.toHaveBeenCalled();
+        expect(this.model.dataviewModel.changedAttributes()).toBe(false);
       });
     });
 
     describe('when there are both widget and dataview attrs names defined', function () {
       beforeEach(function () {
-        this.model.dataviewModel.constructor.ATTRS_NAMES = ['column', 'operation'];
         this.model.set({
           attrsNames: ['title']
         }, { silent: true });
         this.result = this.model.update({
           title: 'new title',
-          column: 'col',
-          operation: 'count',
-          invalid: 'attr, should not be set'
+          column: 'other',
+          aggregation: 'sum',
+          foo: 'attr, should not be set'
         });
       });
 
@@ -90,10 +92,16 @@ describe('widgets/widget-model', function () {
         expect(this.result).toBe(true);
       });
 
-      it('should update the attrs', function () {
+      it('should update the widget', function () {
+        expect(this.model.changedAttributes()).toEqual({
+          title: 'new title'
+        });
+      });
+
+      it('should update the dataview model attrs', function () {
         expect(this.model.dataviewModel.changedAttributes()).toEqual({
-          column: 'col',
-          operation: 'count'
+          column: 'other',
+          aggregation: 'sum'
         });
       });
     });

--- a/spec/widgets/widget-model.spec.js
+++ b/spec/widgets/widget-model.spec.js
@@ -74,9 +74,9 @@ describe('widgets/widget-model', function () {
 
     describe('when there are both widget and dataview attrs names defined', function () {
       beforeEach(function () {
+        this.model.dataviewModel.constructor.ATTRS_NAMES = ['column', 'operation'];
         this.model.set({
-          attrsNames: ['title'],
-          dataviewAttrsNames: ['column', 'operation']
+          attrsNames: ['title']
         }, { silent: true });
         this.result = this.model.update({
           title: 'new title',

--- a/spec/widgets/widget-model.spec.js
+++ b/spec/widgets/widget-model.spec.js
@@ -76,7 +76,7 @@ describe('widgets/widget-model', function () {
       beforeEach(function () {
         this.model.set({
           attrsNames: ['title'],
-          dataviewModelAttrsNames: ['column', 'operation']
+          dataviewAttrsNames: ['column', 'operation']
         }, { silent: true });
         this.result = this.model.update({
           title: 'new title',

--- a/src/widgets-service.js
+++ b/src/widgets-service.js
@@ -3,6 +3,12 @@ var WidgetModel = require('./widgets/widget-model');
 var CategoryWidgetModel = require('./widgets/category/category-widget-model');
 var HistogramWidgetModel = require('./widgets/histogram/histogram-widget-model');
 
+var DEFAULT_DATAVIEW_ATTR_NAMES = [
+  'sync_on_data_change',
+  'sync_on_bbox_change',
+  'enabled'
+];
+
 /**
  * Public API to interact with dashboard widgets.
  */
@@ -47,13 +53,15 @@ WidgetsService.prototype.createCategoryModel = function (attrs, layer) {
     type: 'category',
     title: attrs.title,
     attrsNames: ['title', 'collapsed'],
-    dataviewModelAttrsNames: this._dataviewModelAttrsNames([
-      'column',
-      'aggregation',
-      'aggregation_column',
-      'prefix',
-      'suffix'
-    ])
+    dataviewAttrsNames:
+      [
+        'column',
+        'aggregation',
+        'aggregation_column',
+        'prefix',
+        'suffix'
+      ]
+      .concat(DEFAULT_DATAVIEW_ATTR_NAMES)
   }, {
     dataviewModel: dataviewModel
   });
@@ -88,10 +96,12 @@ WidgetsService.prototype.createHistogramModel = function (attrs, layer) {
     type: 'histogram',
     title: attrs.title,
     attrsNames: ['title', 'collapsed'],
-    dataviewModelAttrsNames: this._dataviewModelAttrsNames([
-      'column',
-      'bins'
-    ])
+    dataviewAttrsNames:
+      [
+        'column',
+        'bins'
+      ]
+      .concat(DEFAULT_DATAVIEW_ATTR_NAMES)
   }, {
     dataviewModel: dataviewModel
   });
@@ -128,12 +138,14 @@ WidgetsService.prototype.createFormulaModel = function (attrs, layer) {
     type: 'formula',
     title: attrs.title,
     attrsNames: ['title', 'collapsed'],
-    dataviewModelAttrsNames: this._dataviewModelAttrsNames([
-      'column',
-      'operation',
-      'prefix',
-      'suffix'
-    ])
+    dataviewAttrsNames:
+      [
+        'column',
+        'operation',
+        'prefix',
+        'suffix'
+      ]
+      .concat(DEFAULT_DATAVIEW_ATTR_NAMES)
   }, {
     dataviewModel: dataviewModel
   });
@@ -168,9 +180,11 @@ WidgetsService.prototype.createListModel = function (attrs, layer) {
     title: attrs.title,
     columns_title: attrs.columns_title,
     attrsNames: ['title'],
-    dataviewModelAttrsNames: this._dataviewModelAttrsNames([
-      'columns'
-    ])
+    dataviewAttrsNames:
+      [
+        'columns'
+      ]
+      .concat(DEFAULT_DATAVIEW_ATTR_NAMES)
   }, {
     dataviewModel: dataviewModel
   });
@@ -207,27 +221,21 @@ WidgetsService.prototype.createTimeSeriesModel = function (attrs, layer) {
   var widgetModel = new WidgetModel({
     id: attrs.id,
     type: 'time-series',
-    dataviewModelAttrsNames: this._dataviewModelAttrsNames([
-      'column',
-      'column_type',
-      'bins',
-      'start',
-      'end'
-    ])
+    dataviewAttrsNames:
+      [
+        'column',
+        'column_type',
+        'bins',
+        'start',
+        'end'
+      ]
+      .concat(DEFAULT_DATAVIEW_ATTR_NAMES)
   }, {
     dataviewModel: dataviewModel
   });
   this._widgetsCollection.add(widgetModel);
 
   return widgetModel;
-};
-
-WidgetsService.prototype._dataviewModelAttrsNames = function (customAttrsNames) {
-  return [
-    'sync_on_data_change',
-    'sync_on_bbox_change',
-    'enabled'
-  ].concat(customAttrsNames);
 };
 
 WidgetsService.prototype._dataviewModelAttrs = function (allAttrs, customAttrs) {

--- a/src/widgets-service.js
+++ b/src/widgets-service.js
@@ -222,7 +222,7 @@ WidgetsService.prototype.createTimeSeriesModel = function (attrs, layer) {
 
 WidgetsService.prototype._dataviewModelAttrsNames = function (customAttrsNames) {
   return [
-    'sync_on_source_change',
+    'sync_on_data_change',
     'sync_on_bbox_change',
     'enabled'
   ].concat(customAttrsNames);
@@ -231,8 +231,8 @@ WidgetsService.prototype._dataviewModelAttrsNames = function (customAttrsNames) 
 WidgetsService.prototype._dataviewModelAttrs = function (allAttrs, customAttrs) {
   return _.extend(
     {
-      sync_on_source_change: _.isBoolean(allAttrs.sync_on_source_change)
-        ? allAttrs.sync_on_source_change
+      sync_on_data_change: _.isBoolean(allAttrs.sync_on_data_change)
+        ? allAttrs.sync_on_data_change
         : true,
       sync_on_bbox_change: _.isBoolean(allAttrs.sync_on_bbox_change)
         ? allAttrs.sync_on_bbox_change

--- a/src/widgets-service.js
+++ b/src/widgets-service.js
@@ -31,7 +31,7 @@ WidgetsService.prototype.createCategoryModel = function (attrs, layer) {
 
   var dataviewModel = this._dataviews.createCategoryModel(layer, attrs);
 
-  var attrsNames = ['id', 'title', 'collapsed'];
+  var attrsNames = ['id', 'title', 'collapsed', 'prefix', 'suffix'];
   var widgetAttrs = _.pick(attrs, attrsNames);
   widgetAttrs.attrsNames = attrsNames;
 
@@ -82,7 +82,7 @@ WidgetsService.prototype.createFormulaModel = function (attrs, layer) {
 
   var dataviewModel = this._dataviews.createFormulaModel(layer, attrs);
 
-  var attrsNames = ['id', 'title', 'collapsed'];
+  var attrsNames = ['id', 'title', 'collapsed', 'prefix', 'suffix'];
   var widgetAttrs = _.pick(attrs, attrsNames);
   widgetAttrs.type = 'formula';
   widgetAttrs.attrsNames = attrsNames;

--- a/src/widgets-service.js
+++ b/src/widgets-service.js
@@ -33,21 +33,25 @@ WidgetsService.prototype.createCategoryModel = function (attrs, layer) {
     throw new Error('Error creating newCategoryModel, ' + err.message);
   }
 
-  var dataviewModel = this._dataviews.createCategoryModel(layer, {
+  var dataviewModel = this._dataviews.createCategoryModel(layer, this._dataviewModelAttrs(attrs, {
     type: 'category',
     column: attrs.column,
     aggregation: attrs.aggregation || 'count',
     aggregation_column: attrs.aggregation_column || attrs.column,
     suffix: attrs.suffix,
     prefix: attrs.prefix
-  });
+  }));
 
   var widgetModel = new CategoryWidgetModel({
     id: attrs.id,
     type: 'category',
     title: attrs.title,
     attrsNames: ['title', 'collapsed'],
-    dataviewModelAttrsNames: ['column', 'aggregation', 'aggregation_column']
+    dataviewModelAttrsNames: this._dataviewModelAttrsNames([
+      'column',
+      'aggregation',
+      'aggregation_column'
+    ])
   }, {
     dataviewModel: dataviewModel
   });
@@ -71,18 +75,21 @@ WidgetsService.prototype.createHistogramModel = function (attrs, layer) {
     throw new Error('Error creating newHistogramModel, ' + err.message);
   }
 
-  var dataviewModel = this._dataviews.createHistogramModel(layer, {
+  var dataviewModel = this._dataviews.createHistogramModel(layer, this._dataviewModelAttrs(attrs, {
     type: 'histogram',
     column: attrs.column,
     bins: attrs.bins || 10
-  });
+  }))
 
   var widgetModel = new HistogramWidgetModel({
     id: attrs.id,
     type: 'histogram',
     title: attrs.title,
     attrsNames: ['title', 'collapsed'],
-    dataviewModelAttrsNames: ['column', 'bins']
+    dataviewModelAttrsNames: this._dataviewModelAttrsNames([
+      'column',
+      'bins'
+    ])
   }, {
     dataviewModel: dataviewModel
   });
@@ -106,20 +113,25 @@ WidgetsService.prototype.createFormulaModel = function (attrs, layer) {
     throw new Error('Error creating newFormulaModel, ' + err.message);
   }
 
-  var dataviewModel = this._dataviews.createFormulaModel(layer, {
+  var dataviewModel = this._dataviews.createFormulaModel(layer, this._dataviewModelAttrs(attrs, {
     type: 'formula',
     column: attrs.column,
     operation: attrs.operation,
     suffix: attrs.suffix,
     prefix: attrs.prefix
-  });
+  }));
 
   var widgetModel = new WidgetModel({
     id: attrs.id,
     type: 'formula',
     title: attrs.title,
     attrsNames: ['title', 'collapsed'],
-    dataviewModelAttrsNames: ['column', 'operation', 'prefix', 'suffix']
+    dataviewModelAttrsNames: this._dataviewModelAttrsNames([
+      'column',
+      'operation',
+      'prefix',
+      'suffix'
+    ])
   }, {
     dataviewModel: dataviewModel
   });
@@ -143,10 +155,10 @@ WidgetsService.prototype.createListModel = function (attrs, layer) {
     throw new Error('Error creating newListModel, ' + err.message);
   }
 
-  var dataviewModel = this._dataviews.createListModel(layer, {
+  var dataviewModel = this._dataviews.createListModel(layer, this._dataviewModelAttrs(attrs, {
     type: 'list',
     columns: attrs.columns
-  });
+  }));
 
   var widgetModel = new WidgetModel({
     id: attrs.id,
@@ -154,7 +166,9 @@ WidgetsService.prototype.createListModel = function (attrs, layer) {
     title: attrs.title,
     columns_title: attrs.columns_title,
     attrsNames: ['title'],
-    dataviewModelAttrsNames: ['columns']
+    dataviewModelAttrsNames: this._dataviewModelAttrsNames([
+      'columns'
+    ])
   }, {
     dataviewModel: dataviewModel
   });
@@ -179,25 +193,56 @@ WidgetsService.prototype.createTimeSeriesModel = function (attrs, layer) {
     throw new Error('Error creating newTimeSeriesModel, ' + err.message);
   }
 
-  var dataviewModel = this._dataviews.createHistogramModel(layer, {
+  var dataviewModel = this._dataviews.createHistogramModel(layer, this._dataviewModelAttrs(attrs, {
     type: 'histogram',
     column: attrs.column,
     column_type: attrs.column_type || 'date',
     bins: attrs.bins,
     start: attrs.start,
     end: attrs.end
-  });
+  }));
 
   var widgetModel = new WidgetModel({
     id: attrs.id,
     type: 'time-series',
-    dataviewModelAttrsNames: ['column', 'column_type', 'bins', 'start', 'end']
+    dataviewModelAttrsNames: this._dataviewModelAttrsNames([
+      'column',
+      'column_type',
+      'bins',
+      'start',
+      'end'
+    ])
   }, {
     dataviewModel: dataviewModel
   });
   this._widgetsCollection.add(widgetModel);
 
   return widgetModel;
+};
+
+WidgetsService.prototype._dataviewModelAttrsNames = function (customAttrsNames) {
+  return [
+    'sync_on_source_change',
+    'sync_on_bbox_change',
+    'enabled'
+  ].concat(customAttrsNames);
+};
+
+WidgetsService.prototype._dataviewModelAttrs = function (allAttrs, customAttrs) {
+  return _.extend(
+    {
+      sync_on_source_change: _.isBoolean(allAttrs.sync_on_source_change)
+        ? allAttrs.sync_on_source_change
+        : true,
+      sync_on_bbox_change: _.isBoolean(allAttrs.sync_on_bbox_change)
+        ? allAttrs.sync_on_bbox_change
+        : true,
+      enabled: _.isBoolean(allAttrs.enabled)
+        ? allAttrs.enabled
+        : true
+    },
+    customAttrs
+  );
 };
 
 function _checkProperties (obj, propertiesArray) {

--- a/src/widgets-service.js
+++ b/src/widgets-service.js
@@ -79,7 +79,7 @@ WidgetsService.prototype.createHistogramModel = function (attrs, layer) {
     type: 'histogram',
     column: attrs.column,
     bins: attrs.bins || 10
-  }))
+  }));
 
   var widgetModel = new HistogramWidgetModel({
     id: attrs.id,
@@ -248,7 +248,7 @@ WidgetsService.prototype._dataviewModelAttrs = function (allAttrs, customAttrs) 
 function _checkProperties (obj, propertiesArray) {
   _.each(propertiesArray, function (prop) {
     if (obj[prop] === undefined) {
-      throw new Error('\'' + prop + '\' should be provided');
+      throw new Error("'" + prop + "' should be provided");
     }
   });
 }

--- a/src/widgets-service.js
+++ b/src/widgets-service.js
@@ -1,5 +1,4 @@
 var _ = require('underscore');
-var cdb = require('cartodb.js');
 var WidgetModel = require('./widgets/widget-model');
 var CategoryWidgetModel = require('./widgets/category/category-widget-model');
 var HistogramWidgetModel = require('./widgets/histogram/histogram-widget-model');
@@ -31,8 +30,7 @@ WidgetsService.prototype.createCategoryModel = function (attrs, layer) {
   try {
     _checkProperties(attrs, ['title', 'column']);
   } catch (err) {
-    cdb.log.error('Error creating newCategoryModel, ' + err.message);
-    return;
+    throw new Error('Error creating newCategoryModel, ' + err.message);
   }
 
   var dataviewModel = this._dataviews.createCategoryModel(layer, {
@@ -70,8 +68,7 @@ WidgetsService.prototype.createHistogramModel = function (attrs, layer) {
   try {
     _checkProperties(attrs, ['title', 'column']);
   } catch (err) {
-    cdb.log.error('Error creating newHistogramModel, ' + err.message);
-    return;
+    throw new Error('Error creating newHistogramModel, ' + err.message);
   }
 
   var dataviewModel = this._dataviews.createHistogramModel(layer, {
@@ -106,8 +103,7 @@ WidgetsService.prototype.createFormulaModel = function (attrs, layer) {
   try {
     _checkProperties(attrs, ['title', 'column', 'operation']);
   } catch (err) {
-    cdb.log.error('Error creating newFormulaModel, ' + err.message);
-    return;
+    throw new Error('Error creating newFormulaModel, ' + err.message);
   }
 
   var dataviewModel = this._dataviews.createFormulaModel(layer, {
@@ -144,8 +140,7 @@ WidgetsService.prototype.createListModel = function (attrs, layer) {
   try {
     _checkProperties(attrs, ['title', 'columns', 'columns_title']);
   } catch (err) {
-    cdb.log.error('Error creating newListModel, ' + err.message);
-    return;
+    throw new Error('Error creating newListModel, ' + err.message);
   }
 
   var dataviewModel = this._dataviews.createListModel(layer, {
@@ -181,8 +176,7 @@ WidgetsService.prototype.createTimeSeriesModel = function (attrs, layer) {
   try {
     _checkProperties(attrs, ['column', 'bins', 'start', 'end']);
   } catch (err) {
-    cdb.log.error('Error creating newTimeSeriesModel, ' + err.message);
-    return;
+    throw new Error('Error creating newTimeSeriesModel, ' + err.message);
   }
 
   var dataviewModel = this._dataviews.createHistogramModel(layer, {

--- a/src/widgets-service.js
+++ b/src/widgets-service.js
@@ -38,8 +38,8 @@ WidgetsService.prototype.createCategoryModel = function (attrs, layer) {
     column: attrs.column,
     aggregation: attrs.aggregation || 'count',
     aggregation_column: attrs.aggregation_column || attrs.column,
-    suffix: attrs.suffix,
-    prefix: attrs.prefix
+    prefix: attrs.prefix,
+    suffix: attrs.suffix
   }));
 
   var widgetModel = new CategoryWidgetModel({
@@ -50,7 +50,9 @@ WidgetsService.prototype.createCategoryModel = function (attrs, layer) {
     dataviewModelAttrsNames: this._dataviewModelAttrsNames([
       'column',
       'aggregation',
-      'aggregation_column'
+      'aggregation_column',
+      'prefix',
+      'suffix'
     ])
   }, {
     dataviewModel: dataviewModel

--- a/src/widgets-service.js
+++ b/src/widgets-service.js
@@ -3,12 +3,6 @@ var WidgetModel = require('./widgets/widget-model');
 var CategoryWidgetModel = require('./widgets/category/category-widget-model');
 var HistogramWidgetModel = require('./widgets/histogram/histogram-widget-model');
 
-var DEFAULT_DATAVIEW_ATTR_NAMES = [
-  'sync_on_data_change',
-  'sync_on_bbox_change',
-  'enabled'
-];
-
 /**
  * Public API to interact with dashboard widgets.
  */
@@ -33,36 +27,15 @@ WidgetsService.prototype.get = function (id) {
  * @return {CategoryWidgetModel}
  */
 WidgetsService.prototype.createCategoryModel = function (attrs, layer) {
-  try {
-    _checkProperties(attrs, ['title', 'column']);
-  } catch (err) {
-    throw new Error('Error creating newCategoryModel, ' + err.message);
-  }
+  _checkProperties(attrs, ['title']);
 
-  var dataviewModel = this._dataviews.createCategoryModel(layer, this._dataviewModelAttrs(attrs, {
-    type: 'category',
-    column: attrs.column,
-    aggregation: attrs.aggregation || 'count',
-    aggregation_column: attrs.aggregation_column || attrs.column,
-    prefix: attrs.prefix,
-    suffix: attrs.suffix
-  }));
+  var dataviewModel = this._dataviews.createCategoryModel(layer, attrs);
 
-  var widgetModel = new CategoryWidgetModel({
-    id: attrs.id,
-    type: 'category',
-    title: attrs.title,
-    attrsNames: ['title', 'collapsed'],
-    dataviewAttrsNames:
-      [
-        'column',
-        'aggregation',
-        'aggregation_column',
-        'prefix',
-        'suffix'
-      ]
-      .concat(DEFAULT_DATAVIEW_ATTR_NAMES)
-  }, {
+  var attrsNames = ['id', 'title', 'collapsed'];
+  var widgetAttrs = _.pick(attrs, attrsNames);
+  widgetAttrs.attrsNames = attrsNames;
+
+  var widgetModel = new CategoryWidgetModel(widgetAttrs, {
     dataviewModel: dataviewModel
   });
   this._widgetsCollection.add(widgetModel);
@@ -79,30 +52,16 @@ WidgetsService.prototype.createCategoryModel = function (attrs, layer) {
  * @return {WidgetModel}
  */
 WidgetsService.prototype.createHistogramModel = function (attrs, layer) {
-  try {
-    _checkProperties(attrs, ['title', 'column']);
-  } catch (err) {
-    throw new Error('Error creating newHistogramModel, ' + err.message);
-  }
+  _checkProperties(attrs, ['title']);
 
-  var dataviewModel = this._dataviews.createHistogramModel(layer, this._dataviewModelAttrs(attrs, {
-    type: 'histogram',
-    column: attrs.column,
-    bins: attrs.bins || 10
-  }));
+  var dataviewModel = this._dataviews.createHistogramModel(layer, attrs);
 
-  var widgetModel = new HistogramWidgetModel({
-    id: attrs.id,
-    type: 'histogram',
-    title: attrs.title,
-    attrsNames: ['title', 'collapsed'],
-    dataviewAttrsNames:
-      [
-        'column',
-        'bins'
-      ]
-      .concat(DEFAULT_DATAVIEW_ATTR_NAMES)
-  }, {
+  var attrsNames = ['id', 'title', 'collapsed'];
+  var widgetAttrs = _.pick(attrs, attrsNames);
+  widgetAttrs.type = 'histogram';
+  widgetAttrs.attrsNames = attrsNames;
+
+  var widgetModel = new HistogramWidgetModel(widgetAttrs, {
     dataviewModel: dataviewModel
   });
   this._widgetsCollection.add(widgetModel);
@@ -119,34 +78,16 @@ WidgetsService.prototype.createHistogramModel = function (attrs, layer) {
  * @return {CategoryWidgetModel}
  */
 WidgetsService.prototype.createFormulaModel = function (attrs, layer) {
-  try {
-    _checkProperties(attrs, ['title', 'column', 'operation']);
-  } catch (err) {
-    throw new Error('Error creating newFormulaModel, ' + err.message);
-  }
+  _checkProperties(attrs, ['title']);
 
-  var dataviewModel = this._dataviews.createFormulaModel(layer, this._dataviewModelAttrs(attrs, {
-    type: 'formula',
-    column: attrs.column,
-    operation: attrs.operation,
-    suffix: attrs.suffix,
-    prefix: attrs.prefix
-  }));
+  var dataviewModel = this._dataviews.createFormulaModel(layer, attrs);
 
-  var widgetModel = new WidgetModel({
-    id: attrs.id,
-    type: 'formula',
-    title: attrs.title,
-    attrsNames: ['title', 'collapsed'],
-    dataviewAttrsNames:
-      [
-        'column',
-        'operation',
-        'prefix',
-        'suffix'
-      ]
-      .concat(DEFAULT_DATAVIEW_ATTR_NAMES)
-  }, {
+  var attrsNames = ['id', 'title', 'collapsed'];
+  var widgetAttrs = _.pick(attrs, attrsNames);
+  widgetAttrs.type = 'formula';
+  widgetAttrs.attrsNames = attrsNames;
+
+  var widgetModel = new WidgetModel(widgetAttrs, {
     dataviewModel: dataviewModel
   });
   this._widgetsCollection.add(widgetModel);
@@ -163,29 +104,16 @@ WidgetsService.prototype.createFormulaModel = function (attrs, layer) {
  * @return {WidgetModel}
  */
 WidgetsService.prototype.createListModel = function (attrs, layer) {
-  try {
-    _checkProperties(attrs, ['title', 'columns', 'columns_title']);
-  } catch (err) {
-    throw new Error('Error creating newListModel, ' + err.message);
-  }
+  _checkProperties(attrs, ['title', 'columns_title']);
 
-  var dataviewModel = this._dataviews.createListModel(layer, this._dataviewModelAttrs(attrs, {
-    type: 'list',
-    columns: attrs.columns
-  }));
+  var dataviewModel = this._dataviews.createListModel(layer, attrs);
 
-  var widgetModel = new WidgetModel({
-    id: attrs.id,
-    type: 'list',
-    title: attrs.title,
-    columns_title: attrs.columns_title,
-    attrsNames: ['title'],
-    dataviewAttrsNames:
-      [
-        'columns'
-      ]
-      .concat(DEFAULT_DATAVIEW_ATTR_NAMES)
-  }, {
+  var attrsNames = ['id', 'title', 'columns_title'];
+  var widgetAttrs = _.pick(attrs, attrsNames);
+  widgetAttrs.type = 'list';
+  widgetAttrs.attrsNames = attrsNames;
+
+  var widgetModel = new WidgetModel(widgetAttrs, {
     dataviewModel: dataviewModel
   });
   this._widgetsCollection.add(widgetModel);
@@ -203,34 +131,18 @@ WidgetsService.prototype.createListModel = function (attrs, layer) {
  * @return {WidgetModel}
  */
 WidgetsService.prototype.createTimeSeriesModel = function (attrs, layer) {
-  try {
-    _checkProperties(attrs, ['column', 'bins', 'start', 'end']);
-  } catch (err) {
-    throw new Error('Error creating newTimeSeriesModel, ' + err.message);
-  }
+  _checkProperties(attrs, ['start', 'end']);
 
-  var dataviewModel = this._dataviews.createHistogramModel(layer, this._dataviewModelAttrs(attrs, {
-    type: 'histogram',
-    column: attrs.column,
-    column_type: attrs.column_type || 'date',
-    bins: attrs.bins,
-    start: attrs.start,
-    end: attrs.end
-  }));
+  // TODO will other kind really work for a time-series?
+  attrs.column_type = attrs.column_type || 'date';
+  var dataviewModel = this._dataviews.createHistogramModel(layer, attrs);
 
-  var widgetModel = new WidgetModel({
-    id: attrs.id,
-    type: 'time-series',
-    dataviewAttrsNames:
-      [
-        'column',
-        'column_type',
-        'bins',
-        'start',
-        'end'
-      ]
-      .concat(DEFAULT_DATAVIEW_ATTR_NAMES)
-  }, {
+  var attrsNames = ['id'];
+  var widgetAttrs = _.pick(attrs, attrsNames);
+  widgetAttrs.type = 'time-series';
+  widgetAttrs.attrsNames = attrsNames;
+
+  var widgetModel = new WidgetModel(widgetAttrs, {
     dataviewModel: dataviewModel
   });
   this._widgetsCollection.add(widgetModel);
@@ -238,27 +150,10 @@ WidgetsService.prototype.createTimeSeriesModel = function (attrs, layer) {
   return widgetModel;
 };
 
-WidgetsService.prototype._dataviewModelAttrs = function (allAttrs, customAttrs) {
-  return _.extend(
-    {
-      sync_on_data_change: _.isBoolean(allAttrs.sync_on_data_change)
-        ? allAttrs.sync_on_data_change
-        : true,
-      sync_on_bbox_change: _.isBoolean(allAttrs.sync_on_bbox_change)
-        ? allAttrs.sync_on_bbox_change
-        : true,
-      enabled: _.isBoolean(allAttrs.enabled)
-        ? allAttrs.enabled
-        : true
-    },
-    customAttrs
-  );
-};
-
 function _checkProperties (obj, propertiesArray) {
   _.each(propertiesArray, function (prop) {
     if (obj[prop] === undefined) {
-      throw new Error("'" + prop + "' should be provided");
+      throw new Error(prop + ' is required');
     }
   });
 }

--- a/src/widgets/category/category-widget-model.js
+++ b/src/widgets/category/category-widget-model.js
@@ -10,6 +10,7 @@ module.exports = WidgetModel.extend({
 
   defaults: _.extend(
     {
+      type: 'category',
       search: false,
       locked: false,
       isColorsApplied: false

--- a/src/widgets/category/list/item/item-view.js
+++ b/src/widgets/category/list/item/item-view.js
@@ -49,6 +49,9 @@ module.exports = cdb.core.View.extend({
     this.model.bind('change', this.render, this);
     this.widgetModel.bind('change:search change:isColorsApplied', this.render, this);
     this.add_related_model(this.widgetModel);
+
+    this.dataviewModel.bind('change:prefix change:suffix', this.render, this);
+    this.add_related_model(this.dataviewModel);
   },
 
   _onItemClick: function () {

--- a/src/widgets/category/list/item/item-view.js
+++ b/src/widgets/category/list/item/item-view.js
@@ -37,8 +37,8 @@ module.exports = cdb.core.View.extend({
         percentage: ((value / this.dataviewModel.get('max')) * 100),
         color: this.widgetModel.colors.getColorByCategory(name),
         isDisabled: !this.model.get('selected') ? 'is-disabled' : '',
-        prefix: this.dataviewModel.get('prefix'),
-        suffix: this.dataviewModel.get('suffix')
+        prefix: this.widgetModel.get('prefix'),
+        suffix: this.widgetModel.get('suffix')
       })
     );
 
@@ -47,11 +47,8 @@ module.exports = cdb.core.View.extend({
 
   _initBinds: function () {
     this.model.bind('change', this.render, this);
-    this.widgetModel.bind('change:search change:isColorsApplied', this.render, this);
+    this.widgetModel.bind('change:search change:isColorsApplied change:prefix change:suffix', this.render, this);
     this.add_related_model(this.widgetModel);
-
-    this.dataviewModel.bind('change:prefix change:suffix', this.render, this);
-    this.add_related_model(this.dataviewModel);
   },
 
   _onItemClick: function () {

--- a/src/widgets/category/list/item/search-item-view.js
+++ b/src/widgets/category/list/item/search-item-view.js
@@ -41,6 +41,8 @@ module.exports = cdb.core.View.extend({
 
   _initBinds: function () {
     this.model.bind('change:selected', this.render, this);
+    this.dataviewModel.bind('change:prefix change:suffix', this.render, this);
+    this.add_related_model(this.dataviewModel);
   },
 
   _onItemClick: function () {

--- a/src/widgets/category/list/item/search-item-view.js
+++ b/src/widgets/category/list/item/search-item-view.js
@@ -18,6 +18,7 @@ module.exports = cdb.core.View.extend({
     // the max value and set properly the progress bar and add the
     // necessary suffix and prefix for the item.
     this.dataviewModel = this.options.dataviewModel;
+    this.widgetModel = this.options.widgetModel;
     this._initBinds();
   },
 
@@ -31,8 +32,8 @@ module.exports = cdb.core.View.extend({
         formattedValue: formatter.formatNumber(value),
         percentage: ((value / this.dataviewModel.get('max')) * 100),
         isDisabled: !this.model.get('selected'),
-        prefix: this.dataviewModel.get('prefix'),
-        suffix: this.dataviewModel.get('suffix')
+        prefix: this.widgetModel.get('prefix'),
+        suffix: this.widgetModel.get('suffix')
       })
     );
 
@@ -41,8 +42,9 @@ module.exports = cdb.core.View.extend({
 
   _initBinds: function () {
     this.model.bind('change:selected', this.render, this);
-    this.dataviewModel.bind('change:prefix change:suffix', this.render, this);
-    this.add_related_model(this.dataviewModel);
+
+    this.widgetModel.bind('change:prefix change:suffix', this.render, this);
+    this.add_related_model(this.widgetModel);
   },
 
   _onItemClick: function () {

--- a/src/widgets/category/list/search-items-view.js
+++ b/src/widgets/category/list/search-items-view.js
@@ -63,6 +63,7 @@ module.exports = CategoryItemsView.extend({
   _addItem: function (mdl, $parent) {
     var v = new WidgetSearchCategoryItemView({
       model: mdl,
+      widgetModel: this.widgetModel,
       dataviewModel: this.dataviewModel
     });
     this.addView(v);

--- a/src/widgets/formula/content-view.js
+++ b/src/widgets/formula/content-view.js
@@ -34,13 +34,13 @@ module.exports = cdb.core.View.extend({
     var nulls = !_.isUndefined(this._dataviewModel.get('nulls')) && formatter.formatNumber(this._dataviewModel.get('nulls')) || '-';
     var isCollapsed = this.model.get('collapsed');
 
-    var prefix = this._dataviewModel.get('prefix');
-    var suffix = this._dataviewModel.get('suffix');
+    var prefix = this.model.get('prefix');
+    var suffix = this.model.get('suffix');
 
     this.$el.html(
       template({
         title: this.model.get('title'),
-        operation: this._dataviewModel.get('operation'),
+        operation: this.model.get('operation'),
         value: value,
         formatedValue: format(value),
         nulls: nulls,
@@ -77,8 +77,8 @@ module.exports = cdb.core.View.extend({
   },
 
   _initBinds: function () {
-    this.model.bind('change:title change:collapsed', this.render, this);
-    this._dataviewModel.bind('change:data change:prefix change:suffix', this.render, this);
+    this.model.bind('change:title change:collapsed change:prefix change:suffix', this.render, this);
+    this._dataviewModel.bind('change:data', this.render, this);
     this.add_related_model(this._dataviewModel);
   },
 

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -26,7 +26,7 @@ module.exports = cdb.core.Model.extend({
   update: function (changes) {
     var attrs = _.pick(changes, this.get('attrsNames'));
     this.set(attrs);
-    attrs = _.pick(changes, this.get('dataviewAttrsNames'));
+    attrs = _.pick(changes, this.dataviewModel.constructor.ATTRS_NAMES);
     this.dataviewModel.set(attrs);
     return !!(this.changedAttributes() || this.dataviewModel.changedAttributes());
   },

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -20,14 +20,14 @@ module.exports = cdb.core.Model.extend({
 
   /**
    * @public
-   * @param {Object} changes, not that it should be
+   * @param {Object} attrs, not that it should be
+   * @return {Boolean} true if at least one attribute was changed
    * @throws {Error} Should throw an error if the attrs are invalid or inconsistent
    */
-  update: function (changes) {
-    var attrs = _.pick(changes, this.get('attrsNames'));
-    this.set(attrs);
-    attrs = _.pick(changes, this.dataviewModel.constructor.ATTRS_NAMES);
-    this.dataviewModel.set(attrs);
+  update: function (attrs) {
+    var wAttrs = _.pick(attrs, this.get('attrsNames'));
+    this.set(wAttrs);
+    this.dataviewModel.update(attrs);
     return !!(this.changedAttributes() || this.dataviewModel.changedAttributes());
   },
 

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -11,7 +11,7 @@ var cdb = require('cartodb.js');
 module.exports = cdb.core.Model.extend({
   defaults: {
     attrsNames: [],
-    dataviewModelAttrsNames: []
+    dataviewAttrsNames: []
   },
 
   initialize: function (attrs, opts) {
@@ -26,7 +26,7 @@ module.exports = cdb.core.Model.extend({
   update: function (changes) {
     var attrs = _.pick(changes, this.get('attrsNames'));
     this.set(attrs);
-    attrs = _.pick(changes, this.get('dataviewModelAttrsNames'));
+    attrs = _.pick(changes, this.get('dataviewAttrsNames'));
     this.dataviewModel.set(attrs);
     return !!(this.changedAttributes() || this.dataviewModel.changedAttributes());
   },

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -10,8 +10,7 @@ var cdb = require('cartodb.js');
  */
 module.exports = cdb.core.Model.extend({
   defaults: {
-    attrsNames: [],
-    dataviewAttrsNames: []
+    attrsNames: []
   },
 
   initialize: function (attrs, opts) {


### PR DESCRIPTION
Allows to set `enabled`, `sync_on_data_change` and `sync_on_bbox_change` attrs, to control widgets behavior.

Also, piggy back for other minor fixes that are required for new editor:
- [x] Fixes #107
- [x] ~~Awaits https://github.com/CartoDB/cartodb.js/pull/1054~~ updated dependency
- [x] category dataview, to be reactive to prefix/suffix change, awaits https://github.com/CartoDB/cartodb.js/pull/1056
- [x] push dataviewModel selection of attrs down to dataview instead of here, awaits https://github.com/CartoDB/cartodb.js/pull/1056

@alonsogarciapablo related to the prev PR so you can probably review here too
cc @xavijam @javierarce 