### PR TITLE
Switched enableFilter and disableFilter, which were internally doing …

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "backbone": "1.2.3",
-    "cartodb.js": "CartoDB/cartodb.js#94bb6f3",
+    "cartodb.js": "CartoDB/cartodb.js#53aa111",
     "d3": "3.5.8",
     "jquery": "2.1.4",
     "jstify": "0.12.0",

--- a/spec/widgets/category/category-widget-model.spec.js
+++ b/spec/widgets/category/category-widget-model.spec.js
@@ -171,11 +171,11 @@ describe('widgets/category/category-widget-model', function () {
 
       it('should update ownFilter attr on dataview model', function () {
         this.widgetModel.set('locked', true);
-        expect(this.dataviewModel.disableFilter).toHaveBeenCalled();
-        expect(this.dataviewModel.enableFilter).not.toHaveBeenCalled();
+        expect(this.dataviewModel.enableFilter).toHaveBeenCalled();
+        expect(this.dataviewModel.disableFilter).not.toHaveBeenCalled();
 
         this.widgetModel.set('locked', false);
-        expect(this.dataviewModel.enableFilter).toHaveBeenCalled();
+        expect(this.dataviewModel.disableFilter).toHaveBeenCalled();
       });
     });
   });

--- a/src/widgets/category/category-widget-model.js
+++ b/src/widgets/category/category-widget-model.js
@@ -130,9 +130,9 @@ module.exports = WidgetModel.extend({
 
   _onLockedChange: function (m, isLocked) {
     if (isLocked) {
-      this.dataviewModel.disableFilter();
-    } else {
       this.dataviewModel.enableFilter();
+    } else {
+      this.dataviewModel.disableFilter();
     }
   },
 


### PR DESCRIPTION
This should be merged after: cartodb/cartodb#1074. Basically, the internal implentation of `categoryDataview.enableFilter` and `categoryDataview.disableFilter` were wrong, so we were using those methods wrongly. If the widget is locked, the dataview should fetch data using it's own filter (filter should be enabled). It now makes sense:

```
 _onLockedChange: function (m, isLocked) {
    if (isLocked) {
      this.dataviewModel.enableFilter();
    } else {
      this.dataviewModel.disableFilter();
    }
  },
```

@xavijam: makes sense?