### PR TITLE
Bring operation badget in formula widgets back!

### DIFF
--- a/spec/widgets/formula/content-view.spec.js
+++ b/spec/widgets/formula/content-view.spec.js
@@ -38,4 +38,12 @@ describe('widgets/formula/content-view', function () {
     this.dataviewModel.set('data', 67);
     expect(this.view.$('.js-value').text()).toBe('67');
   });
+
+  it('should render a little badge with the operation', function () {
+    this.dataviewModel.set('operation', 'avg');
+
+    this.view.render();
+
+    expect(this.view.$('.CDB-Widget-tag.CDB-Widget-tag--avg').text().trim()).toEqual('avg');
+  });
 });

--- a/src/widgets/formula/content-view.js
+++ b/src/widgets/formula/content-view.js
@@ -40,7 +40,7 @@ module.exports = cdb.core.View.extend({
     this.$el.html(
       template({
         title: this.model.get('title'),
-        operation: this.model.get('operation'),
+        operation: this._dataviewModel.get('operation'),
         value: value,
         formatedValue: format(value),
         nulls: nulls,


### PR DESCRIPTION
Fixes #161:

<img width="164" alt="screen shot 2016-02-12 at 17 22 13" src="https://cloud.githubusercontent.com/assets/390398/13012831/32c42064-d1ad-11e5-88c5-3d8cbbdc38e2.png">


@viddo PTAL. Thanks!