### PR TITLE
Fix undefined widget ids

### DIFF
--- a/examples/populated-places.html
+++ b/examples/populated-places.html
@@ -31,6 +31,7 @@
 
           "widgets": [
             {
+              "id": "min-population-formula",
               "type": "formula",
               "title": "Min population (disabled sync)",
               "layer_id": "4d82e8df-f21b-4225-b776-61b1bdffde6c",
@@ -41,6 +42,7 @@
                 "operation": "min"
               }
             }, {
+              "id": "max-population-formula",
               "type": "formula",
               "title": "Max population",
               "layer_id": "4d82e8df-f21b-4225-b776-61b1bdffde6c",
@@ -49,6 +51,7 @@
                 "operation": "max"
               }
             }, {
+              "id": "avg-population-formula",
               "type": "formula",
               "title": "Avg population",
               "layer_id": "4d82e8df-f21b-4225-b776-61b1bdffde6c",
@@ -57,6 +60,7 @@
                 "operation": "avg"
               }
             }, {
+              "id": "total-population-formula",
               "type": "formula",
               "title": "Total population",
               "layer_id": "4d82e8df-f21b-4225-b776-61b1bdffde6c",
@@ -65,6 +69,7 @@
                 "operation": "sum"
               }
             }, {
+              "id": "places-count-formula",
               "type": "formula",
               "title": "# places",
               "layer_id": "4d82e8df-f21b-4225-b776-61b1bdffde6c",
@@ -73,6 +78,7 @@
                 "operation": "count"
               }
             }, {
+              "id": "amount-spent-histogram",
               "type": "histogram",
               "title": "Amount spent",
               "layer_id": "4d82e8df-f21b-4225-b776-61b1bdffde6c",
@@ -81,6 +87,7 @@
                 "bins": 10
               }
             }, {
+              "id": "population-histogram",
               "type": "histogram",
               "title": "Population",
               "layer_id": "4d82e8df-f21b-4225-b776-61b1bdffde6c",
@@ -89,6 +96,7 @@
                 "bins": 10
               }
             }, {
+              "id": "country-category",
               "type": "category",
               "title": "Country",
               "layer_id": "4d82e8df-f21b-4225-b776-61b1bdffde6c",
@@ -97,6 +105,7 @@
                 "aggregation": "count"
               },
             }, {
+              "id": "rank-category",
               "type": "category",
               "title": "Rank category",
               "layer_id": "4d82e8df-f21b-4225-b776-61b1bdffde6c",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "backbone": "1.2.3",
-    "cartodb.js": "CartoDB/cartodb.js#3b6dcfd",
+    "cartodb.js": "CartoDB/cartodb.js#dceb6d3",
     "d3": "3.5.8",
     "jquery": "2.1.4",
     "jstify": "0.12.0",


### PR DESCRIPTION
Utilizes the fix from
https://github.com/CartoDB/cartodb.js/commit/dceb6d30dae3e8898eb284ba206
53d4f53e4a076 https://github.com/CartoDB/cartodb.js/pull/1095 which
uses the provided ID from the widget definition if available, or
fallback on a generated temporary one (dataview-type + cid)

@acanimal 