### PR TITLE
Fixes histogram normalisation bug

### DIFF
--- a/spec/widgets/histogram/chart.spec.js
+++ b/spec/widgets/histogram/chart.spec.js
@@ -162,6 +162,25 @@ describe('widgets/histogram/chart', function () {
       this.view.model.set({ data: genHistogramData(20) });
       expect(this.view.refresh).toHaveBeenCalled();
     });
+
+    describe('should allow to manage the y scale', function () {
+      beforeEach(function () {
+        this.originalScale = this.view.yScale;
+        this.view.model.set('data', genHistogramData(10));
+      });
+
+      it('should calculate the y scale on request', function () {
+        expect(this.view.yScale).toEqual(this.originalScale);
+
+        this.view.updateYScale();
+        expect(this.view.yScale).not.toEqual(this.originalScale);
+      });
+
+      it('should restore the y scale on request', function () {
+        this.view.resetYScale();
+        expect(this.view.yScale).toEqual(this.originalScale);
+      });
+    });
   });
 });
 

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -88,6 +88,7 @@ module.exports = cdb.core.View.extend({
     var labelsMargin = this.model.get('showLabels')
       ? this.options.labelsMargin
       : 0;
+
     return this.model.get('height') - m.top - m.bottom - labelsMargin;
   },
 
@@ -467,11 +468,31 @@ module.exports = cdb.core.View.extend({
     this._onWindowResize();
   },
 
-  _setupScales: function () {
-    var data = this.model.get('data');
+  _getXScale: function () {
+    return d3.scale.linear().domain([0, 100]).range([0, this.chartWidth()]);
+  },
 
-    this.xScale = d3.scale.linear().domain([0, 100]).range([0, this.chartWidth()]);
-    this.yScale = d3.scale.linear().domain([0, d3.max(data, function (d) { return _.isEmpty(d) ? 0 : d.freq; })]).range([this.chartHeight(), 0]);
+  _getYScale: function () {
+    var data = this.model.get('data');
+    return d3.scale.linear().domain([0, d3.max(data, function (d) { return _.isEmpty(d) ? 0 : d.freq; })]).range([this.chartHeight(), 0]);
+  },
+
+  updateYScale: function () {
+    this.yScale = this._getYScale();
+  },
+
+  resetYScale: function () {
+    this.yScale = this._originalYScale;
+  },
+
+  _setupScales: function () {
+    this.xScale = this._getXScale();
+
+    if (!this._originalYScale) {
+      this._originalYScale = this.yScale = this._getYScale();
+    }
+
+    var data = this.model.get('data');
 
     if (!data || !data.length) {
       return;
@@ -1005,6 +1026,7 @@ module.exports = cdb.core.View.extend({
     var self = this;
 
     var yScale = d3.scale.linear().domain([0, d3.max(data, function (d) { return _.isEmpty(d) ? 0 : d.freq; })]).range([this.chartHeight(), 0]);
+
     var barWidth = this.chartWidth() / data.length;
 
     this.chart.append('g')

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -413,8 +413,8 @@ module.exports = cdb.core.View.extend({
 
   _onZoomIn: function () {
     this._showMiniRange();
+    this.histogramChartView.updateYScale();
     this.histogramChartView.expand(4);
-
     this.histogramChartView.removeShadowBars();
 
     this._dataviewModel.set({ start: null, end: null, bins: null, own_filter: 1 });
@@ -439,6 +439,7 @@ module.exports = cdb.core.View.extend({
 
     this.filter.unsetRange();
 
+    this.histogramChartView.resetYScale();
     this.histogramChartView.contract(this.defaults.chartHeight);
     this.histogramChartView.resetIndexes();
 


### PR DESCRIPTION
This PR introduces a change that allows to calculate and store the original vertical scale (`yScale`), fixing a bug with the representation of data.

Now the `yScale` is calculated once and stored. The calls to retrieve more data are represented based on the original scale. The scale can be updated (using the `updateYScale` method) or reverted to its original values (with `resetYScale`).

CR: @javisantana 