### PR TITLE
Hide widgets stats by default

### DIFF
--- a/examples/populated-places.html
+++ b/examples/populated-places.html
@@ -39,7 +39,8 @@
                 "column": "pop_max",
                 "sync_on_data_change": false,
                 "sync_on_bbox_change": false,
-                "operation": "min"
+                "operation": "min",
+                "show_stats": true
               }
             }, {
               "id": "max-population-formula",
@@ -84,7 +85,8 @@
               "layer_id": "4d82e8df-f21b-4225-b776-61b1bdffde6c",
               "options": {
                 "column": "pop_max",
-                "bins": 10
+                "bins": 10,
+                "show_stats": true
               }
             }, {
               "id": "population-histogram",
@@ -102,7 +104,8 @@
               "layer_id": "4d82e8df-f21b-4225-b776-61b1bdffde6c",
               "options": {
                 "column": "adm0_a3",
-                "aggregation": "count"
+                "aggregation": "count",
+                "show_stats": true
               },
             }, {
               "id": "rank-category",

--- a/spec/widgets/category/content-view.spec.js
+++ b/spec/widgets/category/content-view.spec.js
@@ -1,4 +1,5 @@
 var specHelper = require('../../spec-helper');
+var _ = require('underscore');
 var CategoryWidgetModel = require('../../../src/widgets/category/category-widget-model');
 var CategoryContentView = require('../../../src/widgets/category/content-view');
 

--- a/spec/widgets/category/content-view.spec.js
+++ b/spec/widgets/category/content-view.spec.js
@@ -20,8 +20,16 @@ describe('widgets/category/content-view', function () {
     this.renderResult = this.view.render();
   });
 
-  it('should render ifine', function () {
+  it('should render fine', function () {
     expect(this.renderResult).toBe(this.view);
+  });
+
+  it('should render category stats if show_stats is enabled', function () {
+    expect(_.size(this.view._subviews)).toBe(6);
+    this.model.set('show_stats', true);
+    this.view.render();
+    expect(_.size(this.view._subviews)).toBe(7);
+    expect(this.view.$('.CDB-Widget-info').length).toBe(1);
   });
 
   afterEach(function () {

--- a/spec/widgets/formula/content-view.spec.js
+++ b/spec/widgets/formula/content-view.spec.js
@@ -38,4 +38,11 @@ describe('widgets/formula/content-view', function () {
     this.dataviewModel.set('data', 67);
     expect(this.view.$('.js-value').text()).toBe('67');
   });
+
+  it('should render formula stats if show_stats is enabled', function () {
+    expect(this.view.$('.CDB-Widget-info').length).toBe(0);
+    this.model.set('show_stats', true);
+    this.view.render();
+    expect(this.view.$('.CDB-Widget-info').length).toBe(1);
+  });
 });

--- a/spec/widgets/histogram/content-view.spec.js
+++ b/spec/widgets/histogram/content-view.spec.js
@@ -120,6 +120,13 @@ describe('widgets/histogram/content-view', function () {
     expect(this.widgetModel.get('total')).not.toBe(0);
   });
 
+  it('should show stats when show_stats is true', function () {
+    expect(this.view.$('.CDB-Widget-info').length).toBe(0);
+    this.widgetModel.set('show_stats', true);
+    this.view.render();
+    expect(this.view.$('.CDB-Widget-info').length).toBe(1);
+  });
+
   afterEach(function () {
     this.view.clean();
   });

--- a/src/widgets-service.js
+++ b/src/widgets-service.js
@@ -31,7 +31,7 @@ WidgetsService.prototype.createCategoryModel = function (attrs, layer) {
 
   var dataviewModel = this._dataviews.createCategoryModel(layer, attrs);
 
-  var attrsNames = ['id', 'title', 'collapsed', 'prefix', 'suffix'];
+  var attrsNames = ['id', 'title', 'collapsed', 'prefix', 'suffix', 'show_stats'];
   var widgetAttrs = _.pick(attrs, attrsNames);
   widgetAttrs.attrsNames = attrsNames;
 
@@ -56,7 +56,7 @@ WidgetsService.prototype.createHistogramModel = function (attrs, layer) {
 
   var dataviewModel = this._dataviews.createHistogramModel(layer, attrs);
 
-  var attrsNames = ['id', 'title', 'collapsed'];
+  var attrsNames = ['id', 'title', 'collapsed', 'show_stats'];
   var widgetAttrs = _.pick(attrs, attrsNames);
   widgetAttrs.type = 'histogram';
   widgetAttrs.attrsNames = attrsNames;
@@ -82,7 +82,7 @@ WidgetsService.prototype.createFormulaModel = function (attrs, layer) {
 
   var dataviewModel = this._dataviews.createFormulaModel(layer, attrs);
 
-  var attrsNames = ['id', 'title', 'collapsed', 'prefix', 'suffix'];
+  var attrsNames = ['id', 'title', 'collapsed', 'prefix', 'suffix', 'show_stats'];
   var widgetAttrs = _.pick(attrs, attrsNames);
   widgetAttrs.type = 'formula';
   widgetAttrs.attrsNames = attrsNames;
@@ -108,7 +108,7 @@ WidgetsService.prototype.createListModel = function (attrs, layer) {
 
   var dataviewModel = this._dataviews.createListModel(layer, attrs);
 
-  var attrsNames = ['id', 'title', 'columns_title'];
+  var attrsNames = ['id', 'title', 'columns_title', 'show_stats'];
   var widgetAttrs = _.pick(attrs, attrsNames);
   widgetAttrs.type = 'list';
   widgetAttrs.attrsNames = attrsNames;

--- a/src/widgets/category/content-view.js
+++ b/src/widgets/category/content-view.js
@@ -42,12 +42,14 @@ module.exports = cdb.core.View.extend({
     this.$('.js-header').append(searchTitle.render().el);
     this.addView(searchTitle);
 
-    var stats = new CategoryStatsView({
-      widgetModel: this.model,
-      dataviewModel: this._dataviewModel
-    });
-    this.$('.js-header').append(stats.render().el);
-    this.addView(stats);
+    if (this.model.get('show_stats')) {
+      var stats = new CategoryStatsView({
+        widgetModel: this.model,
+        dataviewModel: this._dataviewModel
+      });
+      this.$('.js-header').append(stats.render().el);
+      this.addView(stats);
+    }
 
     var options = new CategoryOptionsView({
       widgetModel: this.model,

--- a/src/widgets/formula/content-view.js
+++ b/src/widgets/formula/content-view.js
@@ -40,6 +40,7 @@ module.exports = cdb.core.View.extend({
     this.$el.html(
       template({
         title: this.model.get('title'),
+        showStats: this.model.get('show_stats'),
         operation: this._dataviewModel.get('operation'),
         value: value,
         formatedValue: format(value),

--- a/src/widgets/formula/template.tpl
+++ b/src/widgets/formula/template.tpl
@@ -11,9 +11,11 @@
       </button>
     </div>
   </div>
-  <dl class="CDB-Widget-info CDB-Text CDB-Size-small u-secondaryTextColor u-upperCase">
-    <dt class="CDB-Widget-infoCount"><%- nulls %></dt><dd class="CDB-Widget-infoDescription">null rows</dd>
-  </dl>
+  <% if (showStats) { %>
+    <dl class="CDB-Widget-info CDB-Text CDB-Size-small u-secondaryTextColor u-upperCase">
+      <dt class="CDB-Widget-infoCount"><%- nulls %></dt><dd class="CDB-Widget-infoDescription">null rows</dd>
+    </dl>
+  <% } %>
 </div>
 <div class="CDB-Widget-content">
   <% if (_.isNumber(value)) { %>

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -128,6 +128,7 @@ module.exports = cdb.core.View.extend({
     this.$el.html(
       template({
         title: this._dataviewModel.get('title'),
+        showStats: this.model.get('show_stats'),
         itemsCount: !isDataEmpty ? data.length : '-'
       })
     );

--- a/src/widgets/histogram/content.tpl
+++ b/src/widgets/histogram/content.tpl
@@ -4,12 +4,14 @@
       <h3 class="CDB-Text CDB-Size-large u-ellipsis js-title"><%- title %></h3>
     </div>
   </div>
-  <dl class="CDB-Widget-info CDB-Text CDB-Size-small u-secondaryTextColor u-upperCase">
-    <dt class="CDB-Widget-infoCount js-nulls">0</dt><dd class="CDB-Widget-infoDescription">NULL ROWS</dd>
-    <dt class="CDB-Widget-infoCount js-min">0</dt><dd class="CDB-Widget-infoDescription">MIN</dd>
-    <dt class="CDB-Widget-infoCount js-avg">0</dt><dd class="CDB-Widget-infoDescription">AVG</dd>
-    <dt class="CDB-Widget-infoCount js-max">0</dt><dd class="CDB-Widget-infoDescription">MAX</dd>
-  </dl>
+  <% if (showStats) { %>
+    <dl class="CDB-Widget-info CDB-Text CDB-Size-small u-secondaryTextColor u-upperCase">
+      <dt class="CDB-Widget-infoCount js-nulls">0</dt><dd class="CDB-Widget-infoDescription">NULL ROWS</dd>
+      <dt class="CDB-Widget-infoCount js-min">0</dt><dd class="CDB-Widget-infoDescription">MIN</dd>
+      <dt class="CDB-Widget-infoCount js-avg">0</dt><dd class="CDB-Widget-infoDescription">AVG</dd>
+      <dt class="CDB-Widget-infoCount js-max">0</dt><dd class="CDB-Widget-infoDescription">MAX</dd>
+    </dl>
+  <% } %>
 </div>
 <div class="CDB-Widget-content CDB-Widget-content--histogram js-content">
   <div class="CDB-Widget-tooltip CDB-Widget-tooltip--light CDB-Text CDB-Size-small js-tooltip"></div>

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -10,7 +10,8 @@ var cdb = require('cartodb.js');
  */
 module.exports = cdb.core.Model.extend({
   defaults: {
-    attrsNames: []
+    attrsNames: [],
+    show_stats: false
   },
 
   initialize: function (attrs, opts) {


### PR DESCRIPTION
But if you want to show them, just set `show_stats` attribute to true.
I've found it easy to add, did I miss something? Missing any test?

![screen shot 2016-02-17 at 16 37 45](https://cloud.githubusercontent.com/assets/132146/13114801/5d36d698-d595-11e5-858e-53ab01095ec2.png)
---
![screen shot 2016-02-17 at 16 37 50](https://cloud.githubusercontent.com/assets/132146/13114802/5d6e0e10-d595-11e5-9e56-f7077fa2efb7.png)
---
![screen shot 2016-02-17 at 16 37 56](https://cloud.githubusercontent.com/assets/132146/13114805/5f6f52c8-d595-11e5-966d-0b24d11afad4.png)


CR: @viddo  