### PR TITLE
WIP - Histogram loses state on collapse/expand

### DIFF
--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -22,7 +22,8 @@ module.exports = cdb.core.View.extend({
     animationBarDelay: function (d, i) {
       return Math.random() * (100 + (i * 10));
     },
-    transitionType: 'elastic'
+    transitionType: 'elastic',
+    filter: [null, null]
   },
 
   initialize: function () {
@@ -660,7 +661,6 @@ module.exports = cdb.core.View.extend({
 
   _setupBrush: function () {
     var self = this;
-
     var brush = this.brush = d3.svg.brush().x(this.xScale);
 
     function onBrushEnd () {
@@ -709,6 +709,14 @@ module.exports = cdb.core.View.extend({
         self._selectRange(loPosition, hiPosition);
         self.trigger('on_brush_end', self.model.get('lo_index'), self.model.get('hi_index'));
       }
+    }
+
+    var filter = this.options.filter;
+    if (filter && filter.length && _.isNumber(filter[0]) && _.isNumber(filter[1])) {
+      this._onBrushStart();
+      this.brush.extent(filter);
+      this._onBrushMove();
+      onBrushEnd.bind(this.brush);
     }
 
     this.brush

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -146,11 +146,6 @@ module.exports = cdb.core.View.extend({
       this._setupBindings();
       this.$el.toggleClass('is-collapsed', !!this.model.get('collapsed'));
       this._initViews();
-
-      if (!this.model.get('collapsed')) {
-        // Trigger events to force update values
-        this.model.trigger('change:avg change:min change:max change:total change:null change:filter_enabled');
-      }
     }
 
     return this;

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -139,6 +139,11 @@ module.exports = cdb.core.View.extend({
       this._setupBindings();
       this.$el.toggleClass('is-collapsed', !!this.model.get('collapsed'));
       this._initViews();
+
+      if (!this.model.get('collapsed')) {
+        // Trigger events to force update values
+        this.model.trigger('change:avg change:min change:max change:total change:null');
+      }
     }
 
     return this;

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -127,7 +127,11 @@ module.exports = cdb.core.View.extend({
       template({
         title: this.model.get('title'),
         showStats: this.model.get('show_stats'),
-        itemsCount: !isDataEmpty ? data.length : '-'
+        itemsCount: !isDataEmpty ? data.length : '-',
+        nulls: formatter.formatNumber(this.model.get('nulls')),
+        min: formatter.formatNumber(this.model.get('min')),
+        avg: formatter.formatNumber(this.model.get('avg')),
+        max: formatter.formatNumber(this.model.get('max'))
       })
     );
 

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -134,6 +134,9 @@ module.exports = cdb.core.View.extend({
         max: formatter.formatNumber(this.model.get('max'))
       })
     );
+    // Force refresh buttons state.
+    this._onChangeFilterEnabled();
+    this._onChangeZoomEnabled();
 
     if (isDataEmpty) {
       this._addPlaceholder();

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -201,7 +201,11 @@ module.exports = cdb.core.View.extend({
     this.addView(this.miniHistogramChartView);
     this.$('.js-content').append(this.miniHistogramChartView.el);
     this.miniHistogramChartView.bind('on_brush_end', this._onMiniRangeUpdated, this);
-    this.miniHistogramChartView.render();
+    if (this._isZoomed()) {
+      this.miniHistogramChartView.render().show();
+    } else {
+      this.miniHistogramChartView.render();
+    }
   },
 
   _setupBindings: function () {

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -142,7 +142,7 @@ module.exports = cdb.core.View.extend({
 
       if (!this.model.get('collapsed')) {
         // Trigger events to force update values
-        this.model.trigger('change:avg change:min change:max change:total change:null');
+        this.model.trigger('change:avg change:min change:max change:total change:null change:filter_enabled');
       }
     }
 

--- a/src/widgets/histogram/content.tpl
+++ b/src/widgets/histogram/content.tpl
@@ -2,10 +2,10 @@
   <div class="js-title"></div>
   <% if (showStats) { %>
     <dl class="CDB-Widget-info CDB-Text CDB-Size-small u-secondaryTextColor u-upperCase">
-      <dt class="CDB-Widget-infoCount js-nulls">0</dt><dd class="CDB-Widget-infoDescription">NULL ROWS</dd>
-      <dt class="CDB-Widget-infoCount js-min">0</dt><dd class="CDB-Widget-infoDescription">MIN</dd>
-      <dt class="CDB-Widget-infoCount js-avg">0</dt><dd class="CDB-Widget-infoDescription">AVG</dd>
-      <dt class="CDB-Widget-infoCount js-max">0</dt><dd class="CDB-Widget-infoDescription">MAX</dd>
+      <dt class="CDB-Widget-infoCount js-nulls"><%- nulls ? nulls : '-' %></dt><dd class="CDB-Widget-infoDescription">NULL ROWS</dd>
+      <dt class="CDB-Widget-infoCount js-min"><%- min ? min : '-' %></dt><dd class="CDB-Widget-infoDescription">MIN</dd>
+      <dt class="CDB-Widget-infoCount js-avg"><%- avg ? avg : '-' %></dt><dd class="CDB-Widget-infoDescription">AVG</dd>
+      <dt class="CDB-Widget-infoCount js-max"><%- max ? max : '-' %></dt><dd class="CDB-Widget-infoDescription">MAX</dd>
     </dl>
   <% } %>
 </div>


### PR DESCRIPTION
CR @javierarce 

close #160 

This PR tries to solved all the issues related with histogram state. When the widget is collapsed and later expanded it:

- loses the stats values, 
- the clear/zoom buttons state,
- lose any filter (on main or zoomed chart) 
- forget the fact if the histogram was zoomed or not, that is, if you are in zoomed mode and collapse/expand the zoomed chart is lost.

