### PR TITLE
Fixes histogram zooming

### DIFF
--- a/spec/widgets/histogram/content-view.spec.js
+++ b/spec/widgets/histogram/content-view.spec.js
@@ -97,11 +97,11 @@ describe('widgets/histogram/content-view', function () {
     };
 
     spyOn(this.view, '_updateStats').and.callThrough();
-    spyOn(this.view, '_onChangeModel').and.callThrough();
+    spyOn(this.view, '_onHistogramDataChanged').and.callThrough();
     this.dataviewModel.fetch();
     this.dataviewModel._data.reset(genHistogramData(20));
     this.dataviewModel.trigger('change:data');
-    expect(this.view._onChangeModel).toHaveBeenCalled();
+    expect(this.view._onHistogramDataChanged).toHaveBeenCalled();
     expect(this.view._updateStats).toHaveBeenCalled();
   });
 

--- a/spec/widgets/histogram/content-view.spec.js
+++ b/spec/widgets/histogram/content-view.spec.js
@@ -145,6 +145,28 @@ describe('widgets/histogram/content-view', function () {
     expect(callback).not.toHaveBeenCalled();
   });
 
+  it('should replace the data of the histogramChartView when user zooms in', function () {
+    var i = 0;
+    this.dataviewModel.sync = function (method, model, options) {
+      options.success({
+        'bin_width': 10,
+        'bins_count': 2,
+        'bins_start': i++,
+        'nulls': 0,
+        'bins': []
+      });
+    };
+
+    this.dataviewModel.fetch();
+
+    spyOn(this.view.histogramChartView, 'replaceData');
+
+    // Click ZOOM
+    this.view.$el.find('.js-zoom').click();
+
+    expect(this.view.histogramChartView.replaceData).toHaveBeenCalled();
+  });
+
   it('should update the stats values', function () {
     expect(this.widgetModel.get('min')).toBe(undefined);
     expect(this.widgetModel.get('max')).toBe(undefined);

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -458,6 +458,5 @@ module.exports = cdb.core.View.extend({
   _clear: function () {
     this.histogramChartView.removeSelection();
     this.model.set({ zoomed: false, zoom_enabled: false });
-    this.model.trigger('change:zoomed');
   }
 });

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -419,8 +419,8 @@ module.exports = cdb.core.View.extend({
     this.histogramChartView.removeShadowBars();
 
     this._dataviewModel.set({ start: null, end: null, bins: null, own_filter: 1 }, { silent: true });
-    this._dataviewModel.fetch();
     this.lockedByUser = false;
+    this._dataviewModel.fetch();
   },
 
   _zoom: function () {

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -66,7 +66,7 @@ module.exports = cdb.core.View.extend({
     this.render();
     this._storeBounds();
 
-    this._dataviewModel.bind('change', this._onChangeModel, this);
+    this._dataviewModel.bind('change:data', this._onHistogramDataChanged, this);
     this.add_related_model(this._dataviewModel);
     this._dataviewModel.fetch();
   },
@@ -85,7 +85,7 @@ module.exports = cdb.core.View.extend({
     return this.model.get('zoomed');
   },
 
-  _onChangeModel: function () {
+  _onHistogramDataChanged: function () {
     // When the histogram is zoomed, we don't need to rely
     // on the change url to update the histogram
     // TODO the widget should not know about the URL… could this state be got from the dataview model somehow?
@@ -413,18 +413,17 @@ module.exports = cdb.core.View.extend({
   },
 
   _onZoomIn: function () {
+    this.lockedByUser = false;
     this._showMiniRange();
     this.histogramChartView.updateYScale();
     this.histogramChartView.expand(4);
     this.histogramChartView.removeShadowBars();
 
     this._dataviewModel.set({ start: null, end: null, bins: null, own_filter: 1 }, { silent: true });
-    this.lockedByUser = false;
     this._dataviewModel.fetch();
   },
 
   _zoom: function () {
-    this.lockedByUser = true;
     this.model.set({ zoomed: true, zoom_enabled: false });
     this.histogramChartView.removeSelection();
   },


### PR DESCRIPTION
There was a race condition and the zoom/clear feature of the histogram widget wasn't working properly when fetching data from GeoJSON tiles. This PR fixes that. I verified that things are still working :ok_hand: on the raster world with these changes.

![histogrrrrram](https://cloud.githubusercontent.com/assets/390398/13143758/631f6a00-d646-11e5-9675-9314457a13c6.gif)

@javierarce could you please CR? Thanks!

Fixes CartoDB/cartodb.js#1089