### PR TITLE
Fix shadow bars problem

### DIFF
--- a/spec/widgets/histogram/content-view.spec.js
+++ b/spec/widgets/histogram/content-view.spec.js
@@ -32,6 +32,13 @@ describe('widgets/histogram/content-view', function () {
     expect(this.view.$('h3').text()).toBe('Howdy');
   });
 
+  it('should reset original data when render the histogram and there is data', function () {
+    spyOn(this.view._originalData, 'reset');
+    this.dataviewModel._data.reset(genHistogramData(20));
+    this.dataviewModel.trigger('change:data');
+    expect(this.view._originalData.reset).toHaveBeenCalled();
+  });
+
   it('should revert the lockedByUser state when the model is changed', function () {
     spyOn(this.view, '_unsetRange').and.callThrough();
 

--- a/spec/widgets/histogram/content-view.spec.js
+++ b/spec/widgets/histogram/content-view.spec.js
@@ -148,6 +148,17 @@ describe('widgets/histogram/content-view', function () {
     expect(this.dataviewModel.disableFilter).toHaveBeenCalled();
   });
 
+  it('should replace histogram chart data with dataview model data when unsets range', function () {
+    spyOn(this.dataviewModel, 'getData').and.returnValue(['0', '1']);
+    this.view.render();
+    spyOn(this.view._originalData, 'toJSON');
+    spyOn(this.view.histogramChartView, 'replaceData');
+    this.view._unsetRange();
+    expect(this.view.histogramChartView.replaceData).toHaveBeenCalled();
+    expect(this.dataviewModel.getData).toHaveBeenCalled();
+    expect(this.view._originalData.toJSON).not.toHaveBeenCalled();
+  });
+
   it('should replace the data of the histogramChartView when user zooms in', function () {
     var i = 0;
     this.dataviewModel.sync = function (method, model, options) {
@@ -192,7 +203,7 @@ describe('widgets/histogram/content-view', function () {
     expect(this.view.$('.CDB-Widget-info').length).toBe(1);
   });
 
-  it('should update data of the mini histogram if there is a bins change and it is not zoomed', function () {
+  it('should update data and original data of the mini histogram if there is a bins change and it is not zoomed', function () {
     var i = 0;
     this.dataviewModel.sync = function (method, model, options) {
       options.success({
@@ -206,11 +217,13 @@ describe('widgets/histogram/content-view', function () {
 
     this.dataviewModel.fetch();
 
+    spyOn(this.view._originalData, 'reset');
     spyOn(this.view, '_isZoomed').and.returnValue(false);
     spyOn(this.view.miniHistogramChartView, 'replaceData');
     // Change data
     this.dataviewModel.update({bins: 10});
     expect(this.view.miniHistogramChartView.replaceData).toHaveBeenCalled();
+    expect(this.view._originalData.reset).toHaveBeenCalled();
   });
 
   afterEach(function () {

--- a/src/widgets-service.js
+++ b/src/widgets-service.js
@@ -56,7 +56,7 @@ WidgetsService.prototype.createHistogramModel = function (attrs, layer) {
 
   var dataviewModel = this._dataviews.createHistogramModel(layer, attrs);
 
-  var attrsNames = ['id', 'title', 'collapsed', 'show_stats'];
+  var attrsNames = ['id', 'title', 'collapsed', 'bins', 'show_stats'];
   var widgetAttrs = _.pick(attrs, attrsNames);
   widgetAttrs.type = 'histogram';
   widgetAttrs.attrsNames = attrsNames;

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -28,13 +28,6 @@ module.exports = cdb.core.View.extend({
   initialize: function () {
     this._originalData = this.options.originalData;
 
-    if (this._originalData) {
-      this._originalData.bind('reset', function () {
-        this._removeShadowBars();
-        this._generateShadowBars();
-      }, this);
-    }
-
     if (!_.isNumber(this.options.height)) throw new Error('height is required');
 
     _.bindAll(this, '_selectBars', '_adjustBrushHandles', '_onBrushMove', '_onBrushStart', '_onMouseMove', '_onMouseOut');
@@ -469,6 +462,14 @@ module.exports = cdb.core.View.extend({
     this.model.bind('change:showLabels', this._onChangShowLabels, this);
     this.model.bind('change:show_shadow_bars', this._onChangeShowShadowBars, this);
     this.model.bind('change:width', this._onChangeWidth, this);
+
+    if (this._originalData) {
+      this._originalData.bind('reset', function () {
+        this._removeShadowBars();
+        this._generateShadowBars();
+      }, this);
+      this.add_related_model(this._originalData);
+    }
   },
 
   _setupDimensions: function () {
@@ -1023,7 +1024,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _generateShadowBars: function () {
-    var data = this._originalData && this._originalData.toJSON();
+    var data = this._originalData && this._originalData.toJSON() || this.model.get('data');
 
     if (!data || !data.length || !this.model.get('show_shadow_bars')) {
       this._removeShadowBars();

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -1014,7 +1014,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _generateShadowBars: function () {
-    var data = this.model.get('data');
+    var data = this.options.originalData;
 
     if (!data || !data.length || !this.model.get('show_shadow_bars')) {
       this._removeShadowBars();

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -26,6 +26,15 @@ module.exports = cdb.core.View.extend({
   },
 
   initialize: function () {
+    this._originalData = this.options.originalData;
+
+    if (this._originalData) {
+      this._originalData.bind('reset', function () {
+        this._removeShadowBars();
+        this._generateShadowBars();
+      }, this);
+    }
+
     if (!_.isNumber(this.options.height)) throw new Error('height is required');
 
     _.bindAll(this, '_selectBars', '_adjustBrushHandles', '_onBrushMove', '_onBrushStart', '_onMouseMove', '_onMouseOut');
@@ -1014,7 +1023,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _generateShadowBars: function () {
-    var data = this.options.originalData;
+    var data = this._originalData && this._originalData.toJSON();
 
     if (!data || !data.length || !this.model.get('show_shadow_bars')) {
       this._removeShadowBars();

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -135,6 +135,7 @@ module.exports = cdb.core.View.extend({
       this._addPlaceholder();
       this._initTitleView();
     } else {
+      this._originalData.reset(this._dataviewModel.getData());
       this._setupBindings();
       this.$el.toggleClass('is-collapsed', !!this.model.get('collapsed'));
       this._initViews();

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
 var cdb = require('cartodb.js');
+var Backbone = require('backbone');
 var formatter = require('../../formatter');
 var HistogramTitleView = require('./histogram-title-view');
 var HistogramChartView = require('./chart');
@@ -25,6 +26,7 @@ module.exports = cdb.core.View.extend({
   },
 
   initialize: function () {
+    this._originalData = new Backbone.Collection();
     this._dataviewModel = this.model.dataviewModel;
     this.filter = this._dataviewModel.filter;
     this.lockedByUser = false;
@@ -95,8 +97,10 @@ module.exports = cdb.core.View.extend({
         this.zoomedData = this._dataviewModel.getData();
       } else {
         this.histogramChartView.showShadowBars();
-        this.originalData = this._dataviewModel.getData();
-        this.miniHistogramChartView.replaceData(this.originalData);
+        if (this._originalData.size() === 0) {
+          this._originalData.reset(this._dataviewModel.getData());
+        }
+        this.miniHistogramChartView.replaceData(this._dataviewModel.getData());
       }
       this.histogramChartView.replaceData(this._dataviewModel.getData());
     }
@@ -131,7 +135,7 @@ module.exports = cdb.core.View.extend({
       this._addPlaceholder();
       this._initTitleView();
     } else {
-      this.originalData = this._dataviewModel.getData();
+      // this._originalData.reset(this._dataviewModel.getData());
       this._setupBindings();
       this.$el.toggleClass('is-collapsed', !!this.model.get('collapsed'));
       this._initViews();
@@ -142,7 +146,7 @@ module.exports = cdb.core.View.extend({
 
   _unsetRange: function () {
     this.unsettingRange = false;
-    this.histogramChartView.replaceData(this.originalData);
+    this.histogramChartView.replaceData(this._originalData.toJSON());
     this.model.set({ lo_index: null, hi_index: null });
 
     if (!this._isZoomed()) {
@@ -163,7 +167,7 @@ module.exports = cdb.core.View.extend({
       width: this.canvasWidth,
       height: this.defaults.chartHeight,
       data: this._dataviewModel.getData(),
-      originalData: this.originalData,
+      originalData: this._originalData,
       displayShadowBars: true
     }));
 
@@ -194,6 +198,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _setupBindings: function () {
+    this._dataviewModel.bind('change:bins', this._onChangeBins, this);
     this.model.bind('change:zoomed', this._onChangeZoomed, this);
     this.model.bind('change:zoom_enabled', this._onChangeZoomEnabled, this);
     this.model.bind('change:filter_enabled', this._onChangeFilterEnabled, this);
@@ -230,7 +235,7 @@ module.exports = cdb.core.View.extend({
     this._clearTooltip();
     this.histogramChartView.removeSelection();
 
-    var data = this.originalData;
+    var data = this._originalData.toJSON();
 
     if (loBarIndex >= 0 && loBarIndex < data.length && (hiBarIndex - 1) >= 0 && (hiBarIndex - 1) < data.length) {
       this.filter.setRange(
@@ -298,6 +303,10 @@ module.exports = cdb.core.View.extend({
     this.$('.js-filter').toggleClass('is-hidden', !this.model.get('filter_enabled'));
   },
 
+  _onChangeBins: function () {
+    this._originalData.reset([]); // Clean originalData
+  },
+
   _onChangeZoomEnabled: function () {
     this.$('.js-zoom').toggleClass('is-hidden', !this.model.get('zoom_enabled'));
   },
@@ -349,7 +358,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _updateStats: function () {
-    var data = this.originalData;
+    var data = this._originalData.toJSON();
 
     if (this._isZoomed()) {
       data = this.zoomedData;

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -163,6 +163,7 @@ module.exports = cdb.core.View.extend({
       width: this.canvasWidth,
       height: this.defaults.chartHeight,
       data: this._dataviewModel.getData(),
+      originalData: this.originalData,
       displayShadowBars: true
     }));
 

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -97,7 +97,7 @@ module.exports = cdb.core.View.extend({
         this.zoomedData = this._dataviewModel.getData();
       } else {
         this.histogramChartView.showShadowBars();
-        if (this._originalData.size() === 0) {
+        if (this._originalData.isEmpty()) {
           this._originalData.reset(this._dataviewModel.getData());
         }
         this.miniHistogramChartView.replaceData(this._dataviewModel.getData());
@@ -135,7 +135,6 @@ module.exports = cdb.core.View.extend({
       this._addPlaceholder();
       this._initTitleView();
     } else {
-      // this._originalData.reset(this._dataviewModel.getData());
       this._setupBindings();
       this.$el.toggleClass('is-collapsed', !!this.model.get('collapsed'));
       this._initViews();
@@ -146,7 +145,7 @@ module.exports = cdb.core.View.extend({
 
   _unsetRange: function () {
     this.unsettingRange = false;
-    this.histogramChartView.replaceData(this._originalData.toJSON());
+    this.histogramChartView.replaceData(this._dataviewModel.getData());
     this.model.set({ lo_index: null, hi_index: null });
 
     if (!this._isZoomed()) {
@@ -159,6 +158,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _renderMainChart: function () {
+    console.log("hello?");
     this.histogramChartView = new HistogramChartView(({
       margin: { top: 4, right: 4, bottom: 4, left: 4 },
       hasShadowBards: true,

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -158,7 +158,6 @@ module.exports = cdb.core.View.extend({
   },
 
   _renderMainChart: function () {
-    console.log("hello?");
     this.histogramChartView = new HistogramChartView(({
       margin: { top: 4, right: 4, bottom: 4, left: 4 },
       hasShadowBards: true,


### PR DESCRIPTION
Basically I didn't take into account `originalData` for the shadow bars, and these were using the same data that the current bars have.
I've tried to not "touch" how things are right now, the main change is that `originalData` is now a `Backbone.Collection`, which provides the data to the 'shadowBars'.
If there is any *bins* change, `originalData` would be emptied and then filled with the new data.

CR: @javierarce 
Fixes #229.