### PR TITLE
Category stats view always rendered and then checking visibility if show_stats is enabled or not

### DIFF
--- a/spec/widgets/category/content-view.spec.js
+++ b/spec/widgets/category/content-view.spec.js
@@ -23,14 +23,7 @@ describe('widgets/category/content-view', function () {
 
   it('should render fine', function () {
     expect(this.renderResult).toBe(this.view);
-  });
-
-  it('should render category stats if show_stats is enabled', function () {
-    expect(_.size(this.view._subviews)).toBe(6);
-    this.model.set('show_stats', true);
-    this.view.render();
     expect(_.size(this.view._subviews)).toBe(7);
-    expect(this.view.$('.CDB-Widget-info').length).toBe(1);
   });
 
   afterEach(function () {

--- a/spec/widgets/category/stats-view.spec.js
+++ b/spec/widgets/category/stats-view.spec.js
@@ -33,6 +33,18 @@ describe('widgets/category/stats-view', function () {
       expect(this.view.$('.CDB-Widget-infoDescription:eq(1)').text()).toContain('of total');
     });
 
+    it('should check visibility after rendering', function () {
+      this.dataviewModel._data.reset([
+        { name: 'ES', agg: false, value: 2 },
+        { name: 'FR', agg: false, value: 2 },
+        { name: 'Other', agg: true, value: 1 }
+      ]);
+      spyOn(this.view, '_checkVisibility').and.callThrough();
+      this.view.render();
+      expect(this.view.$('.CDB-Widget-infoDescription:eq(1)').text()).toContain('of total');
+      expect(this.view._checkVisibility).toHaveBeenCalled();
+    });
+
     describe('search', function () {
       it('should show number of results when a search is applied', function () {
         spyOn(this.widgetModel, 'isSearchEnabled').and.returnValue(true);
@@ -72,6 +84,27 @@ describe('widgets/category/stats-view', function () {
       expect(bind[0]).toContain('change:search');
       expect(bind[0]).toContain('change:locked');
       expect(bind[1]).toEqual(this.view.render);
+    });
+  });
+
+  describe('._checkVisibility', function () {
+    beforeEach(function () {
+      this.dataviewModel._data.reset([
+        { name: 'FR', agg: false, value: 2 },
+        { name: 'US', agg: false, value: 2 },
+        { name: 'Other', agg: true, value: 1 }
+      ]);
+      this.view.render();
+    });
+
+    it('should show stats if show_stats attribute is enabled', function () {
+      this.widgetModel.set('show_stats', true);
+      expect(this.view.$el.css('display')).not.toBe('none');
+    });
+
+    it('should hide stats if show_stats attribute is enabled', function () {
+      this.widgetModel.set('show_stats', false);
+      expect(this.view.$el.css('display')).toBe('none');
     });
   });
 });

--- a/src/widgets/category/content-view.js
+++ b/src/widgets/category/content-view.js
@@ -42,14 +42,12 @@ module.exports = cdb.core.View.extend({
     this.$('.js-header').append(searchTitle.render().el);
     this.addView(searchTitle);
 
-    if (this.model.get('show_stats')) {
-      var stats = new CategoryStatsView({
-        widgetModel: this.model,
-        dataviewModel: this._dataviewModel
-      });
-      this.$('.js-header').append(stats.render().el);
-      this.addView(stats);
-    }
+    var stats = new CategoryStatsView({
+      widgetModel: this.model,
+      dataviewModel: this._dataviewModel
+    });
+    this.$('.js-header').append(stats.render().el);
+    this.addView(stats);
 
     var options = new CategoryOptionsView({
       widgetModel: this.model,

--- a/src/widgets/category/stats/stats-view.js
+++ b/src/widgets/category/stats/stats-view.js
@@ -42,12 +42,15 @@ module.exports = cdb.core.View.extend({
       animationTemplate, { defaultValue: '-', animationSpeed: 700, formatter: formatter.formatValue }
     );
 
+    this._checkVisibility();
+
     return this;
   },
 
   _initBinds: function () {
     this.dataviewModel.bind('change:data change:totalCount', this.render, this);
     this.widgetModel.bind('change:search change:locked', this.render, this);
+    this.widgetModel.bind('change:show_stats', this._checkVisibility, this);
     this.add_related_model(this.dataviewModel);
     this.add_related_model(this.widgetModel);
   },
@@ -91,5 +94,9 @@ module.exports = cdb.core.View.extend({
       this.dataviewModel.getData().reject(function (mdl) {
         return mdl.get('agg');
       }), 'name').length;
+  },
+
+  _checkVisibility: function () {
+    this.$el.toggle(!!this.widgetModel.get('show_stats'));
   }
 });


### PR DESCRIPTION
Possibility to change the visibility of the category stats view, right now, if show_stats was false, the view was not added and there was not possibility to show it again.

Fixes #246.

CR: @javierarce 