### PR TITLE
Fix 254 Time-series widget renders all data in chart initially instead of only the visible data in bbox

### DIFF
--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -314,7 +314,6 @@ module.exports = cdb.core.View.extend({
     this._setupDimensions();
     this._calcBarWidth();
     this._generateChartContent();
-    this._removeShadowBars();
     this._generateShadowBars();
   },
 
@@ -324,7 +323,6 @@ module.exports = cdb.core.View.extend({
     this._generateAxis();
     this._updateChart();
 
-    this._generateShadowBars();
     this.chart.select('.CDB-Chart-handles').moveToFront();
     this.chart.select('.Brush').moveToFront();
   },

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -161,7 +161,6 @@ module.exports = cdb.core.View.extend({
   _renderMainChart: function () {
     this.histogramChartView = new HistogramChartView(({
       margin: { top: 4, right: 4, bottom: 4, left: 4 },
-      hasShadowBards: true,
       hasHandles: true,
       hasAxisTip: true,
       width: this.canvasWidth,

--- a/src/widgets/time-series/content-view.js
+++ b/src/widgets/time-series/content-view.js
@@ -41,14 +41,6 @@ module.exports = cdb.core.View.extend({
     return this;
   },
 
-  _onFirstLoad: function () {
-    this._dataviewModel.once('change:data', this.render, this);
-    this._dataviewModel.fetch();
-    if (!this._isDataEmpty()) {
-      this.render();
-    }
-  },
-
   _appendView: function (view) {
     this.addView(view);
     this.$el.append(view.render().el);
@@ -57,5 +49,10 @@ module.exports = cdb.core.View.extend({
   _isDataEmpty: function () {
     var data = this._dataviewModel.getData();
     return _.isEmpty(data) || _.size(data) === 0;
+  },
+
+  _onFirstLoad: function () {
+    this.render();
+    this._dataviewModel.fetch(); // do an explicit fetch again, to get actual data with the filters applied (e.g. bbox)
   }
 });

--- a/src/widgets/time-series/histogram-view.js
+++ b/src/widgets/time-series/histogram-view.js
@@ -45,7 +45,8 @@ module.exports = cdb.core.View.extend({
         return (i * 3);
       },
       height: this.defaults.histogramChartHeight,
-      data: this.model.getData()
+      data: this.model.getData(),
+      displayShadowBars: true
     });
     this.addView(this._chartView);
     this.$el.append(this._chartView.render().el);

--- a/src/widgets/time-series/torque-content-view.js
+++ b/src/widgets/time-series/torque-content-view.js
@@ -13,11 +13,7 @@ module.exports = cdb.core.View.extend({
 
   initialize: function () {
     this._dataviewModel = this.model.dataviewModel;
-    this._initBinds();
-  },
-
-  _initBinds: function () {
-    this._dataviewModel.once('change:data', this.render, this);
+    this._dataviewModel.once('change:data', this._onFirstDataChange, this);
     this.add_related_model(this._dataviewModel);
   },
 
@@ -61,5 +57,10 @@ module.exports = cdb.core.View.extend({
   _isDataEmpty: function () {
     var data = this._dataviewModel.getData();
     return _.isEmpty(data) || _.size(data) === 0;
+  },
+
+  _onFirstDataChange: function () {
+    this.render();
+    this._dataviewModel.fetch(); // do an explicit fetch again, to get actual data with the filters applied (e.g. bbox)
   }
 });

--- a/src/widgets/time-series/torque-histogram-view.js
+++ b/src/widgets/time-series/torque-histogram-view.js
@@ -115,16 +115,21 @@ module.exports = cdb.core.View.extend({
   },
 
   _reSelectRange: function () {
-    function clamp (a, b, t) {
-      return Math.max(a, Math.min(b, t));
+    if (!this._rangeFilter.isEmpty()) {
+      var loStep = this.timeToStep(this._rangeFilter.get('min'));
+      var hiStep = this.timeToStep(this._rangeFilter.get('max'));
+
+      // clamp values since the range can be outside of the current torque thing
+      var steps = this._torqueLayerModel.get('steps');
+      this._torqueLayerModel.renderRange(
+        this._clampRangeVal(0, steps, loStep), // start
+        this._clampRangeVal(0, steps, hiStep) // end
+      );
     }
-    var loStep = this.timeToStep(this._rangeFilter.get('min'));
-    var hiStep = this.timeToStep(this._rangeFilter.get('max'));
-    // clamp values since the range can be outside of the current torque thing
-    this._torqueLayerModel.renderRange(
-      clamp(0, this._torqueLayerModel.get('steps'), loStep),
-      clamp(0, this._torqueLayerModel.get('steps'), hiStep)
-    );
+  },
+
+  _clampRangeVal: function (a, b, t) {
+    return Math.max(a, Math.min(b, t));
   },
 
   _onChangeChartWidth: function () {


### PR DESCRIPTION
Fixes #254 

Bonus fix: Don't pause the torque animation on data change/range reset :dancer: 

@javierarce review, please :bow: 