### PR TITLE
Use original data for creating the chart Y scale

### DIFF
--- a/spec/widgets/histogram/content-view.spec.js
+++ b/spec/widgets/histogram/content-view.spec.js
@@ -104,7 +104,6 @@ describe('widgets/histogram/content-view', function () {
       options.success({ 'response': true });
     };
     spyOn(this.dataviewModel, 'getData').and.callThrough();
-    spyOn(this.view._originalData, 'toJSON');
     spyOn(this.view, '_updateStats').and.callThrough();
     spyOn(this.view, '_onHistogramDataChanged');
     this.dataviewModel.fetch();
@@ -113,7 +112,6 @@ describe('widgets/histogram/content-view', function () {
     expect(this.view._onHistogramDataChanged).toHaveBeenCalled();
     expect(this.view._updateStats).toHaveBeenCalled();
     expect(this.dataviewModel.getData).toHaveBeenCalled();
-    expect(this.view._originalData.toJSON).not.toHaveBeenCalled();
   });
 
   it('should update the title when the model is updated', function () {

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -481,7 +481,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _getYScale: function () {
-    var data = this.model.get('data');
+    var data = (this._originalData && this._originalData.toJSON()) || this.model.get('data');
     return d3.scale.linear().domain([0, d3.max(data, function (d) { return _.isEmpty(d) ? 0 : d.freq; })]).range([this.chartHeight(), 0]);
   },
 


### PR DESCRIPTION
Preventing this problem in the zoomed histogram:

Before:
![screen shot 2016-03-04 at 11 49 35](https://cloud.githubusercontent.com/assets/132146/13525078/2fab64e8-e1ff-11e5-8a34-c751f04159e7.png)

After: 
![screen shot 2016-03-04 at 11 51 06](https://cloud.githubusercontent.com/assets/132146/13525117/6aba6fca-e1ff-11e5-9f07-6bcf6274d499.png)


cc @javierarce 