### PR TITLE
Changing way to use original data within histogram in order to fix 'vector histograms'

### DIFF
--- a/examples/time-series-widget.html
+++ b/examples/time-series-widget.html
@@ -47,21 +47,6 @@
                 "bins": 10
               }
             }, {
-              "type": "list",
-              "title": "Arboles",
-              "layer_id": "4d82e8df-f21b-4225-b776-61b1bdffde6c",
-              "options": {
-                "bbox": false,
-                "columns": [
-                  "cartodb_id",
-                  "name"
-                ],
-                "columns_title": [
-                  "id",
-                  "tipo"
-                ]
-              }
-            }, {
               "type": "time-series",
               "layer_id": "101e17db-1466-4842-8eef-f81da32f48db",
               "options": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "backbone": "1.2.3",
-    "cartodb.js": "CartoDB/cartodb.js#302d83a",
+    "cartodb.js": "CartoDB/cartodb.js#fedda47",
     "d3": "3.5.8",
     "jquery": "2.1.4",
     "jstify": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "backbone": "1.2.3",
-    "cartodb.js": "CartoDB/cartodb.js#fedda47",
+    "cartodb.js": "CartoDB/cartodb.js#510e928",
     "d3": "3.5.8",
     "jquery": "2.1.4",
     "jstify": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "backbone": "1.2.3",
-    "cartodb.js": "CartoDB/cartodb.js#510e928",
+    "cartodb.js": "CartoDB/cartodb.js#a01a3ac",
     "d3": "3.5.8",
     "jquery": "2.1.4",
     "jstify": "0.12.0",

--- a/spec/dashboard-below-map-view.spec.js
+++ b/spec/dashboard-below-map-view.spec.js
@@ -21,6 +21,9 @@ describe('dashboard-below-map-view', function () {
         type: 'time-series'
       });
       timeSeriesWidgetModelFake.dataviewModel = new cdb.core.Model();
+      timeSeriesWidgetModelFake.dataviewModel.getUnfilteredDataModel = function () {
+        return new cdb.core.Model();
+      };
       timeSeriesWidgetModelFake.dataviewModel.getData = function () {
         return {};
       };

--- a/spec/widgets/histogram/content-view.spec.js
+++ b/spec/widgets/histogram/content-view.spec.js
@@ -11,6 +11,14 @@ describe('widgets/histogram/content-view', function () {
       column: 'col'
     });
 
+    this.originalData = this.dataviewModel._unfilteredData;
+    this.originalData.set({
+      data: [{ bin: 10 }, { bin: 3 }],
+      start: 0,
+      end: 256,
+      bins: 2
+    });
+
     this.widgetModel = new HistogramWidgetModel({
       title: 'Howdy',
       attrsNames: ['title']
@@ -18,245 +26,225 @@ describe('widgets/histogram/content-view', function () {
       dataviewModel: this.dataviewModel
     });
 
+    spyOn(this.dataviewModel, 'fetch').and.callThrough();
     this.view = new HistogramContentView({
       model: this.widgetModel,
       dataviewModel: this.dataviewModel
     });
   });
 
-  it('should render the histogram', function () {
-    spyOn(this.view, 'render').and.callThrough();
-    this.dataviewModel._data.reset(genHistogramData(20));
-    this.dataviewModel.trigger('change:data');
-    expect(this.view.render).toHaveBeenCalled();
-    expect(this.view.$('h3').text()).toBe('Howdy');
+  describe('unfilteredData is not loaded', function () {
+    it('should render histogram when unfilteredData changes', function () {
+      spyOn(this.view, 'render').and.callThrough();
+      this.originalData.trigger('change:data', this.originalData);
+      expect(this.view.render).toHaveBeenCalled();
+      expect(this.view.$('h3').text()).toBe('Howdy');
+    });
+
+    it('should not fetch data until unfilteredData changes', function () {
+      expect(this.dataviewModel.fetch).not.toHaveBeenCalled();
+      this.originalData.trigger('change:data', this.originalData);
+      expect(this.dataviewModel.fetch).toHaveBeenCalled();
+    });
   });
 
-  it('should reset original data when render the histogram and there is data', function () {
-    spyOn(this.view._originalData, 'reset');
-    this.dataviewModel._data.reset(genHistogramData(20));
-    this.dataviewModel.trigger('change:data');
-    expect(this.view._originalData.reset).toHaveBeenCalled();
-  });
+  describe('unfilteredData is loaded', function () {
+    beforeEach(function () {
+      this.originalData.trigger('change:data', this.originalData);
+    });
 
-  it('should revert the lockedByUser state when the model is changed', function () {
-    spyOn(this.view, '_unsetRange').and.callThrough();
+    it('should revert the lockedByUser state when the model is changed', function () {
+      spyOn(this.view, '_unsetRange').and.callThrough();
 
-    this.dataviewModel.sync = function (method, model, options) {
-      options.success({ 'response': true });
-    };
+      this.dataviewModel.sync = function (method, model, options) {
+        options.success({ 'response': true });
+      };
 
-    this.widgetModel.set('zoomed', true);
-    this.dataviewModel.fetch();
+      this.widgetModel.set('zoomed', true);
+      this.dataviewModel.fetch();
 
-    expect(this.view._unsetRange).not.toHaveBeenCalled();
+      expect(this.view._unsetRange).not.toHaveBeenCalled();
 
-    this.view.lockedByUser = true;
-    this.dataviewModel.set('url', 'test');
+      this.view.lockedByUser = true;
+      this.dataviewModel.set('url', 'test');
 
-    expect(this.view.lockedByUser).toBe(true);
-  });
+      expect(this.view.lockedByUser).toBe(true);
+    });
 
-  it("shouldn't revert the lockedByUser state when the url is changed and the histogram is zoomed", function () {
-    this.dataviewModel.sync = function (method, model, options) {
-      options.success({ 'response': true });
-    };
+    it("shouldn't revert the lockedByUser state when the url is changed and the histogram is zoomed", function () {
+      this.dataviewModel.sync = function (method, model, options) {
+        options.success({ 'response': true });
+      };
 
-    this.view.lockedByUser = true;
-    this.dataviewModel.fetch();
-    this.dataviewModel.trigger('change:data');
-    expect(this.view.lockedByUser).toBe(false);
-  });
+      this.view.lockedByUser = true;
+      this.dataviewModel.fetch();
+      this.dataviewModel.trigger('change:data');
+      expect(this.view.lockedByUser).toBe(false);
+    });
 
-  it('should unset the range when the data is changed', function () {
-    this.dataviewModel.sync = function (method, model, options) {
-      options.success({ 'response': true });
-    };
+    it('should unset the range when the data is changed', function () {
+      this.dataviewModel.sync = function (method, model, options) {
+        options.success({ 'response': true });
+      };
 
-    spyOn(this.view, '_unsetRange').and.callThrough();
-    this.view.unsettingRange = true;
-    this.dataviewModel.fetch();
-    this.dataviewModel._data.reset(genHistogramData(20));
-    this.dataviewModel.trigger('change:data');
-    expect(this.view._unsetRange).toHaveBeenCalled();
-  });
+      spyOn(this.view, '_unsetRange').and.callThrough();
+      this.view.unsettingRange = true;
+      this.dataviewModel.fetch();
+      this.dataviewModel._data.reset(genHistogramData(20));
+      this.dataviewModel.trigger('change:data');
+      expect(this.view._unsetRange).toHaveBeenCalled();
+    });
 
-  it("shouldn't unset the range when the url is changed and is zoomed", function () {
-    spyOn(this.view, '_unsetRange').and.callThrough();
+    it("shouldn't unset the range when the url is changed and is zoomed", function () {
+      spyOn(this.view, '_unsetRange').and.callThrough();
 
-    this.dataviewModel.sync = function (method, model, options) {
-      options.success({ 'response': true });
-    };
+      this.dataviewModel.sync = function (method, model, options) {
+        options.success({ 'response': true });
+      };
 
-    this.widgetModel.set('zoomed', true);
-    this.dataviewModel.fetch();
+      this.widgetModel.set('zoomed', true);
+      this.dataviewModel.fetch();
 
-    expect(this.view._unsetRange).not.toHaveBeenCalled();
+      expect(this.view._unsetRange).not.toHaveBeenCalled();
 
-    this.view.unsettingRange = true;
-    this.dataviewModel.set('url', 'test');
+      this.view.unsettingRange = true;
+      this.dataviewModel.set('url', 'test');
 
-    expect(this.view._unsetRange).not.toHaveBeenCalled();
-  });
+      expect(this.view._unsetRange).not.toHaveBeenCalled();
+    });
 
-  it('should update the stats when the model is changed', function () {
-    this.dataviewModel.sync = function (method, model, options) {
-      options.success({ 'response': true });
-    };
-    spyOn(this.dataviewModel, 'getData').and.callThrough();
-    spyOn(this.view, '_updateStats').and.callThrough();
-    spyOn(this.view, '_onHistogramDataChanged');
-    this.dataviewModel.fetch();
-    this.dataviewModel._data.reset(genHistogramData(20));
-    this.dataviewModel.trigger('change:data');
-    expect(this.view._onHistogramDataChanged).toHaveBeenCalled();
-    expect(this.view._updateStats).toHaveBeenCalled();
-    expect(this.dataviewModel.getData).toHaveBeenCalled();
-  });
+    it('should update the stats when the data of the model has changed', function () {
+      spyOn(this.dataviewModel, 'getData').and.callThrough();
+      spyOn(this.view, '_updateStats').and.callThrough();
+      this.dataviewModel._data.reset(genHistogramData(20));
+      this.dataviewModel.trigger('change:data');
+      expect(this.view._updateStats).toHaveBeenCalled();
+      expect(this.dataviewModel.getData).toHaveBeenCalled();
+    });
 
-  it('should update the title when the model is updated', function () {
-    this.view.render();
-    expect(this.view.$el.html().indexOf('Howdy') !== -1).toBe(true);
-    this.widgetModel.update({title: 'Cloudy'});
-    this.view.render();
-    expect(this.view.$el.html().indexOf('Cloudy') !== -1).toBe(true);
-  });
+    it('should update the title when the model is updated', function () {
+      this.view.render();
+      expect(this.view.$el.html().indexOf('Howdy') !== -1).toBe(true);
+      this.widgetModel.update({title: 'Cloudy'});
+      this.view.render();
+      expect(this.view.$el.html().indexOf('Cloudy') !== -1).toBe(true);
+    });
 
-  it('should enable and disable filters on the dataviewModel when zooming in and out', function () {
-    var histogramData = {
-      'bin_width': 10,
-      'bins_count': 2,
-      'bins_start': 1,
-      'nulls': 0,
-      'bins': []
-    };
+    it('should enable and disable filters on the dataviewModel when zooming in and out', function () {
+      this.dataviewModel.sync = function (method, model, options) {
+        options.success({
+          'bin_width': 10,
+          'bins_count': 2,
+          'bins_start': 1,
+          'nulls': 0,
+          'bins': []
+        });
+      };
+      this.dataviewModel.fetch();
+      spyOn(this.dataviewModel, 'enableFilter');
+      this.view.$('.js-zoom').click();
+      expect(this.dataviewModel.enableFilter).toHaveBeenCalled();
+      spyOn(this.dataviewModel, 'disableFilter');
+      this.view.$('.js-clear').click();
+      expect(this.dataviewModel.disableFilter).toHaveBeenCalled();
+    });
 
-    this.dataviewModel.sync = function (method, model, options) {
-      options.success(histogramData);
-    };
+    it('should replace histogram chart data with dataview model data when unsets range', function () {
+      spyOn(this.dataviewModel, 'getData').and.returnValue(['0', '1']);
+      this.view.render();
+      spyOn(this.view._originalData, 'toJSON');
+      spyOn(this.view.histogramChartView, 'replaceData');
+      this.view._unsetRange();
+      expect(this.view.histogramChartView.replaceData).toHaveBeenCalled();
+      expect(this.dataviewModel.getData).toHaveBeenCalled();
+      expect(this.view._originalData.toJSON).not.toHaveBeenCalled();
+    });
 
-    this.dataviewModel.fetch();
+    it('should replace the data of the histogramChartView when user zooms in', function () {
+      var i = 0;
+      this.dataviewModel.sync = function (method, model, options) {
+        options.success({
+          'bin_width': 10,
+          'bins_count': 2,
+          'bins_start': i++,
+          'nulls': 0,
+          'bins': [{ bin: 10 }, { bin: 1 }]
+        });
+      };
+      spyOn(this.view.histogramChartView, 'replaceData');
+      this.view.$('.js-zoom').click();
+      expect(this.view.histogramChartView.replaceData).toHaveBeenCalled();
+    });
 
-    expect(this.dataviewModel.get('start')).toEqual(1);
-    expect(this.dataviewModel.get('end')).toEqual(21);
-    expect(this.dataviewModel.get('bins')).toEqual(2);
+    it('should update the stats values', function () {
+      expect(this.widgetModel.get('min')).toBe(undefined);
+      expect(this.widgetModel.get('max')).toBe(undefined);
+      expect(this.widgetModel.get('avg')).toBe(undefined);
+      expect(this.widgetModel.get('total')).toBe(undefined);
 
-    spyOn(this.dataviewModel, 'enableFilter');
+      this.dataviewModel._data.reset(genHistogramData(20));
+      this.dataviewModel.trigger('change:data');
 
-    // Click ZOOM
-    this.view.$el.find('.js-zoom').click();
+      expect(this.widgetModel.get('min')).not.toBe(0);
+      expect(this.widgetModel.get('max')).not.toBe(0);
+      expect(this.widgetModel.get('avg')).not.toBe(0);
+      expect(this.widgetModel.get('total')).not.toBe(0);
+    });
 
-    expect(this.dataviewModel.enableFilter).toHaveBeenCalled();
+    it('should show stats when show_stats is true', function () {
+      expect(this.view.$('.CDB-Widget-info').length).toBe(0);
+      this.widgetModel.set('show_stats', true);
+      this.view.render();
+      expect(this.view.$('.CDB-Widget-info').length).toBe(1);
+    });
 
-    spyOn(this.dataviewModel, 'disableFilter');
+    it('should update data and original data of the mini histogram if there is a bins change and it is not zoomed', function () {
+      var i = 0;
+      this.dataviewModel.sync = function (method, model, options) {
+        options.success({
+          'bin_width': 10,
+          'bins_count': 2,
+          'bins_start': i++,
+          'nulls': 0,
+          'bins': []
+        });
+      };
 
-    // Click CLEAR
-    this.view.$el.find('.js-clear').click();
+      this.dataviewModel.fetch();
 
-    expect(this.dataviewModel.disableFilter).toHaveBeenCalled();
-  });
+      spyOn(this.originalData, 'setBins');
+      spyOn(this.view, '_isZoomed').and.returnValue(false);
+      spyOn(this.view.miniHistogramChartView, 'replaceData');
+      // Change data
+      this.dataviewModel.update({bins: 10});
+      expect(this.view.miniHistogramChartView.replaceData).toHaveBeenCalled();
+      expect(this.originalData.setBins).toHaveBeenCalled();
+    });
 
-  it('should replace histogram chart data with dataview model data when unsets range', function () {
-    spyOn(this.dataviewModel, 'getData').and.returnValue(['0', '1']);
-    this.view.render();
-    spyOn(this.view._originalData, 'toJSON');
-    spyOn(this.view.histogramChartView, 'replaceData');
-    this.view._unsetRange();
-    expect(this.view.histogramChartView.replaceData).toHaveBeenCalled();
-    expect(this.dataviewModel.getData).toHaveBeenCalled();
-    expect(this.view._originalData.toJSON).not.toHaveBeenCalled();
-  });
+    it('should remove previous filter if there is a bins change', function () {
+      var i = 0;
+      this.dataviewModel.sync = function (method, model, options) {
+        options.success({
+          'bin_width': 10,
+          'bins_count': 2,
+          'bins_start': i++,
+          'nulls': 0,
+          'bins': []
+        });
+      };
 
-  it('should replace the data of the histogramChartView when user zooms in', function () {
-    var i = 0;
-    this.dataviewModel.sync = function (method, model, options) {
-      options.success({
-        'bin_width': 10,
-        'bins_count': 2,
-        'bins_start': i++,
-        'nulls': 0,
-        'bins': []
-      });
-    };
+      this.dataviewModel.fetch();
 
-    this.dataviewModel.fetch();
-
-    spyOn(this.view.histogramChartView, 'replaceData');
-
-    // Click ZOOM
-    this.view.$el.find('.js-zoom').click();
-
-    expect(this.view.histogramChartView.replaceData).toHaveBeenCalled();
-  });
-
-  it('should update the stats values', function () {
-    expect(this.widgetModel.get('min')).toBe(undefined);
-    expect(this.widgetModel.get('max')).toBe(undefined);
-    expect(this.widgetModel.get('avg')).toBe(undefined);
-    expect(this.widgetModel.get('total')).toBe(undefined);
-
-    this.dataviewModel._data.reset(genHistogramData(20));
-    this.dataviewModel.trigger('change:data');
-
-    expect(this.widgetModel.get('min')).not.toBe(0);
-    expect(this.widgetModel.get('max')).not.toBe(0);
-    expect(this.widgetModel.get('avg')).not.toBe(0);
-    expect(this.widgetModel.get('total')).not.toBe(0);
-  });
-
-  it('should show stats when show_stats is true', function () {
-    expect(this.view.$('.CDB-Widget-info').length).toBe(0);
-    this.widgetModel.set('show_stats', true);
-    this.view.render();
-    expect(this.view.$('.CDB-Widget-info').length).toBe(1);
-  });
-
-  it('should update data and original data of the mini histogram if there is a bins change and it is not zoomed', function () {
-    var i = 0;
-    this.dataviewModel.sync = function (method, model, options) {
-      options.success({
-        'bin_width': 10,
-        'bins_count': 2,
-        'bins_start': i++,
-        'nulls': 0,
-        'bins': []
-      });
-    };
-
-    this.dataviewModel.fetch();
-
-    spyOn(this.view._originalData, 'reset');
-    spyOn(this.view, '_isZoomed').and.returnValue(false);
-    spyOn(this.view.miniHistogramChartView, 'replaceData');
-    // Change data
-    this.dataviewModel.update({bins: 10});
-    expect(this.view.miniHistogramChartView.replaceData).toHaveBeenCalled();
-    expect(this.view._originalData.reset).toHaveBeenCalled();
-  });
-
-  it('should remove previous filter if there is a bins change', function () {
-    var i = 0;
-    this.dataviewModel.sync = function (method, model, options) {
-      options.success({
-        'bin_width': 10,
-        'bins_count': 2,
-        'bins_start': i++,
-        'nulls': 0,
-        'bins': []
-      });
-    };
-
-    this.dataviewModel.fetch();
-
-    spyOn(this.dataviewModel, 'disableFilter');
-    spyOn(this.view.filter, 'unsetRange');
-    // Change data
-    this.dataviewModel.update({bins: 10});
-    expect(this.dataviewModel.disableFilter).toHaveBeenCalled();
-    expect(this.view.filter.unsetRange).toHaveBeenCalled();
-    expect(this.view.model.get('filter_enabled')).toBeFalsy();
-    expect(this.view.model.get('lo_index')).toBeFalsy();
-    expect(this.view.model.get('hi_index')).toBeFalsy();
+      spyOn(this.dataviewModel, 'disableFilter');
+      spyOn(this.view.filter, 'unsetRange');
+      // Change data
+      this.dataviewModel.update({bins: 10});
+      expect(this.dataviewModel.disableFilter).toHaveBeenCalled();
+      expect(this.view.filter.unsetRange).toHaveBeenCalled();
+      expect(this.view.model.get('filter_enabled')).toBeFalsy();
+      expect(this.view.model.get('lo_index')).toBeFalsy();
+      expect(this.view.model.get('hi_index')).toBeFalsy();
+    });
   });
 
   afterEach(function () {

--- a/spec/widgets/histogram/content-view.spec.js
+++ b/spec/widgets/histogram/content-view.spec.js
@@ -149,6 +149,25 @@ describe('widgets/histogram/content-view', function () {
       expect(this.dataviewModel.disableFilter).toHaveBeenCalled();
     });
 
+    it('should set and unset bounds for the histogram view when chart is zoomed in and zoomed out', function () {
+      this.dataviewModel.sync = function (method, model, options) {
+        options.success({
+          'bin_width': 10,
+          'bins_count': 2,
+          'bins_start': 1,
+          'nulls': 0,
+          'bins': []
+        });
+      };
+      this.dataviewModel.fetch();
+      spyOn(this.view.histogramChartView, 'setBounds');
+      spyOn(this.view.histogramChartView, 'unsetBounds');
+      this.view.$('.js-zoom').click();
+      expect(this.view.histogramChartView.setBounds).toHaveBeenCalled();
+      this.view.$('.js-clear').click();
+      expect(this.view.histogramChartView.unsetBounds).toHaveBeenCalled();
+    });
+
     it('should replace histogram chart data with dataview model data when unsets range', function () {
       spyOn(this.dataviewModel, 'getData').and.returnValue(['0', '1']);
       this.view.render();

--- a/spec/widgets/time-series/content-view.spec.js
+++ b/spec/widgets/time-series/content-view.spec.js
@@ -8,6 +8,13 @@ describe('widgets/time-series/content-view', function () {
     this.dataviewModel = vis.dataviews.createHistogramModel(vis.map.layers.first(), {
       column: 'col'
     });
+    this.originalData = this.dataviewModel.getUnfilteredDataModel();
+    this.originalData.set({
+      data: [{ bin: 10 }, { bin: 3 }],
+      start: 0,
+      end: 256,
+      bins: 2
+    });
     this.dataviewModel.sync = function (method, dataviewModel, options) {
       this.options = options;
     }.bind(this);
@@ -16,42 +23,56 @@ describe('widgets/time-series/content-view', function () {
       dataviewModel: this.dataviewModel
     });
 
+    spyOn(this.dataviewModel, 'fetch').and.callThrough();
     this.view = new TimeSeriesContentView({
       model: widgetModel
     });
 
-    this.view.render();
   });
 
-  it('should render', function () {
-    expect(this.view.$el.html()).not.toEqual('');
+  it('should not fetch new data until unfilteredData is loaded', function () {
+    expect(this.dataviewModel.fetch).not.toHaveBeenCalled();
+    this.originalData.trigger('change:data', this.originalData);
+    expect(this.dataviewModel.fetch).toHaveBeenCalled();
   });
 
-  it('should not render chart just yet since have no data', function () {
-    expect(this.view.$el.html()).not.toContain('<svg');
-  });
-
-  describe('when data is provided', function () {
+  describe('when unfilteredData is loaded', function () {
     beforeEach(function () {
-      var timeOffset = 10000;
-      var startTime = (new Date()).getTime() - timeOffset;
-
-      this.dataviewModel.fetch();
-      this.options.success({
-        bins_count: 3,
-        bin_width: 100,
-        nulls: 0,
-        bins_start: 10,
-        bins: [{
-          start: startTime,
-          end: startTime + timeOffset,
-          freq: 3
-        }]
-      });
+      this.originalData.trigger('change:data', this.originalData);
+      this.dataviewModel.trigger('change:data');
     });
 
-    it('should render chart', function () {
-      expect(this.view.render().$el.html()).toContain('<svg');
+    it('should render placeholder', function () {
+      expect(this.view.$el.html()).not.toBe('');
+      expect(this.view.$('.CDB-Widget-content--timeSeries').length).toBe(1);
+    });
+
+    it('should not render chart just yet since have no data', function () {
+      expect(this.view.$el.html()).not.toContain('<svg');
+    });
+
+    describe('when data is provided', function () {
+      beforeEach(function () {
+        var timeOffset = 10000;
+        var startTime = (new Date()).getTime() - timeOffset;
+
+        this.dataviewModel.fetch();
+        this.options.success({
+          bins_count: 3,
+          bin_width: 100,
+          nulls: 0,
+          bins_start: 10,
+          bins: [{
+            start: startTime,
+            end: startTime + timeOffset,
+            freq: 3
+          }]
+        });
+      });
+
+      it('should render chart', function () {
+        expect(this.view.render().$el.html()).toContain('<svg');
+      });
     });
   });
 });

--- a/spec/widgets/time-series/content-view.spec.js
+++ b/spec/widgets/time-series/content-view.spec.js
@@ -27,7 +27,6 @@ describe('widgets/time-series/content-view', function () {
     this.view = new TimeSeriesContentView({
       model: widgetModel
     });
-
   });
 
   it('should not fetch new data until unfilteredData is loaded', function () {

--- a/spec/widgets/time-series/torque-content-view.spec.js
+++ b/spec/widgets/time-series/torque-content-view.spec.js
@@ -1,6 +1,7 @@
 var specHelper = require('../../spec-helper');
 var TorqueTimesSeriesContentView = require('../../../src/widgets/time-series/torque-content-view');
 var WidgetModel = require('../../../src/widgets/widget-model');
+var cdb = require('cartodb.js');
 
 describe('widgets/time-series/torque-content-view', function () {
   beforeEach(function () {
@@ -8,22 +9,30 @@ describe('widgets/time-series/torque-content-view', function () {
     this.dataviewModel = vis.dataviews.createHistogramModel(vis.map.layers.first(), {
       column: 'col'
     });
+    spyOn(this.dataviewModel, 'fetch').and.callThrough();
+    this.originalData = this.dataviewModel.getUnfilteredDataModel();
+    this.originalData.set({
+      data: [{ bin: 10 }, { bin: 3 }],
+      start: 0,
+      end: 256,
+      bins: 2
+    });
     this.dataviewModel.sync = function (method, model, options) {
       this.options = options;
     }.bind(this);
-    this.torqueLayerModel = new cdb.geo.TorqueLayer({
-    });
+    this.torqueLayerModel = new cdb.geo.TorqueLayer();
     var widgetModel = new WidgetModel({}, {
       dataviewModel: this.dataviewModel
     });
     this.view = new TorqueTimesSeriesContentView({
       model: widgetModel
     });
-    this.renderResult = this.view.render();
   });
 
-  it('should render loading state', function () {
-    expect(this.renderResult).toBe(this.view);
+  it('should not fetch new data until unfilteredData is loaded', function () {
+    expect(this.dataviewModel.fetch).not.toHaveBeenCalled();
+    this.originalData.trigger('change:data', this.originalData);
+    expect(this.dataviewModel.fetch).toHaveBeenCalled();
   });
 
   describe('when data is provided', function () {

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -432,7 +432,7 @@ module.exports = cdb.core.View.extend({
 
   _setupModel: function () {
     this.model = new cdb.core.Model({
-      zoom: false,
+      bounded: false,
       showLabels: true,
       data: this.options.data,
       height: this.options.height,

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -494,10 +494,10 @@ module.exports = cdb.core.View.extend({
   },
 
   _getDataForScales: function () {
-    if (this.model.get('bounded')) {
-      return this.model.get('data');
+    if (!this.model.get('bounded') && this._originalData) {
+      return this._originalData.getData();
     } else {
-      return this._originalData && this._originalData.getData();
+      return this.model.get('data');
     }
   },
 

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -462,7 +462,7 @@ module.exports = cdb.core.View.extend({
     this.model.bind('change:width', this._onChangeWidth, this);
 
     if (this._originalData) {
-      this._originalData.bind('reset', function () {
+      this._originalData.on('change:data', function () {
         this._removeShadowBars();
         this._generateShadowBars();
       }, this);
@@ -481,7 +481,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _getYScale: function () {
-    var data = (this._originalData && this._originalData.toJSON()) || this.model.get('data');
+    var data = (this._originalData && this._originalData.getData()) || this.model.get('data');
     return d3.scale.linear().domain([0, d3.max(data, function (d) { return _.isEmpty(d) ? 0 : d.freq; })]).range([this.chartHeight(), 0]);
   },
 
@@ -504,7 +504,7 @@ module.exports = cdb.core.View.extend({
       this._originalYScale = this.yScale = this._getYScale();
     }
 
-    var data = this.model.get('data');
+    var data = (this._originalData && this._originalData.getData()) || this.model.get('data');
 
     if (!data || !data.length) {
       return;
@@ -1026,7 +1026,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _generateShadowBars: function () {
-    var data = this._originalData && this._originalData.toJSON() || this.model.get('data');
+    var data = this._originalData && this._originalData.getData() || this.model.get('data');
 
     if (!data || !data.length || !this.model.get('show_shadow_bars')) {
       this._removeShadowBars();

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -501,7 +501,7 @@ module.exports = cdb.core.View.extend({
       this._originalYScale = this.yScale = this._getYScale();
     }
 
-    if (this.model.get('zoom')) {
+    if (this.model.get('bounded')) {
       data = this.model.get('data');
     } else {
       data = this._originalData && this._originalData.getData();
@@ -1089,7 +1089,7 @@ module.exports = cdb.core.View.extend({
   },
 
   unsetBounds: function () {
-    this.model.set('zoom', false);
+    this.model.set('bounded', false);
     this.resetYScale();
     this.contract(this.options.height);
     this.resetIndexes();
@@ -1097,7 +1097,7 @@ module.exports = cdb.core.View.extend({
   },
 
   setBounds: function () {
-    this.model.set('zoom', true);
+    this.model.set('bounded', true);
     this.updateYScale();
     this.expand(4);
     this.removeShadowBars();

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -493,18 +493,20 @@ module.exports = cdb.core.View.extend({
     this.yScale = this._originalYScale;
   },
 
+  _getDataForScales: function () {
+    if (this.model.get('bounded')) {
+      return this.model.get('data');
+    } else {
+      return this._originalData && this._originalData.getData();
+    }
+  },
+
   _setupScales: function () {
-    var data;
+    var data = this._getDataForScales();
     this.updateXScale();
 
     if (!this._originalYScale) {
       this._originalYScale = this.yScale = this._getYScale();
-    }
-
-    if (this.model.get('bounded')) {
-      data = this.model.get('data');
-    } else {
-      data = this._originalData && this._originalData.getData();
     }
 
     if (!data || !data.length) {

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -113,8 +113,8 @@ module.exports = cdb.core.View.extend({
   render: function () {
     this.clearSubViews();
     var data = this._dataviewModel.getData();
-    var originData = this._originalData.getData();
-    var isDataEmpty = !_.size(data) && !_.size(originData);
+    var originalData = this._originalData.getData();
+    var isDataEmpty = !_.size(data) && !_.size(originalData);
 
     this.$el.html(
       template({

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -93,12 +93,7 @@ module.exports = cdb.core.View.extend({
       this.lockedByUser = false;
     } else {
       if (!this._isZoomed()) {
-      //   this.zoomedData = this._dataviewModel.getData();
-      // } else {
         this.histogramChartView.showShadowBars();
-        // if (this._originalData.isEmpty()) {
-        //   this._originalData.reset(this._dataviewModel.getData());
-        // }
         this.miniHistogramChartView.replaceData(this._dataviewModel.getData());
       }
       this.histogramChartView.replaceData(this._dataviewModel.getData());
@@ -109,7 +104,6 @@ module.exports = cdb.core.View.extend({
     } else {
       if (this._isZoomed() && !this.lockZoomedData) {
         this.lockZoomedData = true;
-        // this.zoomedData = this._dataviewModel.getData();
       }
     }
 
@@ -120,7 +114,7 @@ module.exports = cdb.core.View.extend({
     this.clearSubViews();
     var data = this._dataviewModel.getData();
     var originData = this._originalData.getData();
-    var isDataEmpty = (_.isEmpty(data) || _.size(data) === 0) && (_.isEmpty(originData) || _.size(originData) === 0);
+    var isDataEmpty = !_.size(data) && !_.size(originData);
 
     this.$el.html(
       template({

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -1,6 +1,5 @@
 var _ = require('underscore');
 var cdb = require('cartodb.js');
-var Backbone = require('backbone');
 var formatter = require('../../formatter');
 var HistogramTitleView = require('./histogram-title-view');
 var HistogramChartView = require('./chart');

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -427,9 +427,7 @@ module.exports = cdb.core.View.extend({
       hi_index: null
     });
     this._dataviewModel.disableFilter();
-
     this.filter.unsetRange();
-
     this.histogramChartView.unsetBounds();
     this.miniHistogramChartView.hide();
   }

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -101,10 +101,6 @@ module.exports = cdb.core.View.extend({
 
     if (this.unsettingRange) {
       this._unsetRange();
-    } else {
-      if (this._isZoomed() && !this.lockZoomedData) {
-        this.lockZoomedData = true;
-      }
     }
 
     this._updateStats();
@@ -222,7 +218,6 @@ module.exports = cdb.core.View.extend({
 
   _onMiniRangeUpdated: function (loBarIndex, hiBarIndex) {
     this.lockedByUser = false;
-    this.lockZoomedData = false;
 
     this._clearTooltip();
     this.histogramChartView.removeSelection();
@@ -423,7 +418,6 @@ module.exports = cdb.core.View.extend({
 
   _resetWidget: function () {
     this.lockedByUser = true;
-    this.lockZoomedData = false;
     this.unsettingRange = true;
     this.model.set({
       zoomed: false,

--- a/src/widgets/time-series/content-view.js
+++ b/src/widgets/time-series/content-view.js
@@ -17,7 +17,7 @@ module.exports = cdb.core.View.extend({
 
   render: function () {
     this.clearSubViews();
-    this.$el.html(''); // to remove placeholder if there is any
+    this.$el.empty();
 
     if (this._isDataEmpty()) {
       this.$el.append(placeholderTemplate({

--- a/src/widgets/time-series/histogram-view.js
+++ b/src/widgets/time-series/histogram-view.js
@@ -20,7 +20,7 @@ module.exports = cdb.core.View.extend({
 
   initialize: function () {
     this._rangeFilter = this.options.rangeFilter;
-
+    this._originalData = this.model.getUnfilteredDataModel();
     this.model.bind('change:data', this._onChangeData, this);
   },
 
@@ -33,6 +33,7 @@ module.exports = cdb.core.View.extend({
   _createHistogramView: function () {
     this._chartView = new HistogramChartView({
       type: 'time',
+      chartBarColorClass: 'CDB-Chart-bar--timeSeries',
       animationSpeed: 100,
       margin: {
         top: 4,
@@ -46,6 +47,7 @@ module.exports = cdb.core.View.extend({
       },
       height: this.defaults.histogramChartHeight,
       data: this.model.getData(),
+      originalData: this._originalData,
       displayShadowBars: true
     });
     this.addView(this._chartView);

--- a/src/widgets/time-series/histogram-view.js
+++ b/src/widgets/time-series/histogram-view.js
@@ -1,6 +1,7 @@
 var $ = require('jquery');
 var cdb = require('cartodb.js');
 var HistogramChartView = require('../histogram/chart');
+var TimeSeriesHeaderView = require('./time-series-header-view');
 
 /**
  * Time-series histogram view.
@@ -26,8 +27,19 @@ module.exports = cdb.core.View.extend({
 
   render: function () {
     this.clearSubViews();
+    this._createHeaderView();
     this._createHistogramView();
     return this;
+  },
+
+  _createHeaderView: function () {
+    var headerView = new TimeSeriesHeaderView({
+      dataviewModel: this.model,
+      rangeFilter: this._rangeFilter
+    });
+    headerView.bind('resetFilter', this._onResetFilter, this);
+    this.addView(headerView);
+    this.$el.append(headerView.render().el);
   },
 
   _createHistogramView: function () {
@@ -65,6 +77,11 @@ module.exports = cdb.core.View.extend({
       this._chartView.updateXScale();
       this._chartView.updateYScale();
     }
+  },
+
+  _onResetFilter: function () {
+    this._rangeFilter.unsetRange();
+    this._chartView.removeSelection();
   },
 
   _onBrushEnd: function (loBarIndex, hiBarIndex) {

--- a/src/widgets/time-series/time-series-header-view.js
+++ b/src/widgets/time-series/time-series-header-view.js
@@ -1,0 +1,51 @@
+var cdb = require('cartodb.js');
+var template = require('./time-series-header.tpl');
+var d3 = require('d3');
+
+/**
+ * View to reset render range.
+ */
+module.exports = cdb.core.View.extend({
+  className: 'CDB-Widget-header--timeSeries js-header CDB-Widget-contentSpaced',
+  events: {
+    'click .js-clear': '_onClick'
+  },
+
+  initialize: function () {
+    this._dataviewModel = this.options.dataviewModel;
+    this._rangeFilter = this.options.rangeFilter;
+    this._rangeFilter.bind('change', this.render, this);
+    this._setupScales();
+  },
+
+  render: function () {
+    this.$el.empty();
+    if (!this._rangeFilter.isEmpty()) {
+      this.$el.html(
+        template({
+          timeFormatter: this._timeFormatter,
+          dateFormatter: this._dateFormatter,
+          startDate: new Date(this._scale.invert(this._rangeFilter.get('min'))),
+          endDate: new Date(this._scale.invert(this._rangeFilter.get('max')))
+        })
+      );
+    }
+    return this;
+  },
+
+  _setupScales: function () {
+    var data = this._dataviewModel.get('data');
+    this._scale = d3.time.scale()
+      .domain([data[0].start * 1000, data[data.length - 1].end * 1000])
+      .nice()
+      .range([0, this._dataviewModel.get('bins')]);
+
+    // for format rules see https://github.com/mbostock/d3/wiki/Time-Formatting
+    this._timeFormatter = d3.time.format('%H:%M');
+    this._dateFormatter = d3.time.format('%x');
+  },
+
+  _onClick: function () {
+    this.trigger('resetFilter', this);
+  }
+});

--- a/src/widgets/time-series/time-series-header-view.js
+++ b/src/widgets/time-series/time-series-header-view.js
@@ -38,7 +38,7 @@ module.exports = cdb.core.View.extend({
     this._scale = d3.time.scale()
       .domain([data[0].start * 1000, data[data.length - 1].end * 1000])
       .nice()
-      .range([0, this._dataviewModel.get('bins')]);
+      .range([this._dataviewModel.get('start'), this._dataviewModel.get('end')]);
 
     // for format rules see https://github.com/mbostock/d3/wiki/Time-Formatting
     this._timeFormatter = d3.time.format('%H:%M');

--- a/src/widgets/time-series/time-series-header.tpl
+++ b/src/widgets/time-series/time-series-header.tpl
@@ -1,0 +1,19 @@
+<div>
+  <p class="CDB-Text CDB-Size-large u-iBlock">
+    Selected from
+  </p>
+  <p class="CDB-Text CDB-Size-large u-secondaryTextColor u-iBlock">
+    <%- timeFormatter(startDate) %>
+    <%- dateFormatter(startDate) %>
+  </p>
+  <p class="CDB-Text CDB-Size-large u-iBlock">
+    to
+  </p>
+  <p class="CDB-Text CDB-Size-large u-secondaryTextColor u-iBlock">
+    <%- timeFormatter(endDate) %>
+    <%- dateFormatter(endDate) %>
+  </p>
+</div>
+<div>
+  <button class="CDB-Text CDB-Size-small u-upperCase u-actionTextColor CDB-Widget-filterButton js-clear">Clear selection</button>
+</div>

--- a/src/widgets/time-series/torque-content-view.js
+++ b/src/widgets/time-series/torque-content-view.js
@@ -13,8 +13,8 @@ module.exports = cdb.core.View.extend({
 
   initialize: function () {
     this._dataviewModel = this.model.dataviewModel;
-    this._dataviewModel.once('change:data', this._onFirstDataChange, this);
-    this.add_related_model(this._dataviewModel);
+    this._originalData = this._dataviewModel.getUnfilteredDataModel();
+    this._initBinds();
   },
 
   render: function () {
@@ -49,6 +49,13 @@ module.exports = cdb.core.View.extend({
     return this;
   },
 
+  _initBinds: function () {
+    this._originalData.once('change:data', this._onFirstDataChange, this);
+    this.add_related_model(this._originalData);
+    this._dataviewModel.once('change:data', this.render, this);
+    this.add_related_model(this._dataviewModel);
+  },
+
   _appendView: function (view) {
     this.addView(view);
     view.render();
@@ -59,8 +66,9 @@ module.exports = cdb.core.View.extend({
     return _.isEmpty(data) || _.size(data) === 0;
   },
 
-  _onFirstDataChange: function () {
-    this.render();
-    this._dataviewModel.fetch(); // do an explicit fetch again, to get actual data with the filters applied (e.g. bbox)
+  _onOriginalDataChange: function () {
+    // do an explicit fetch in order to get actual data
+    // with the filters applied (e.g. bbox)
+    this._dataviewModel.fetch();
   }
 });

--- a/src/widgets/time-series/torque-content-view.js
+++ b/src/widgets/time-series/torque-content-view.js
@@ -50,7 +50,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _initBinds: function () {
-    this._originalData.once('change:data', this._onFirstDataChange, this);
+    this._originalData.once('change:data', this._onOriginalDataChange, this);
     this.add_related_model(this._originalData);
     this._dataviewModel.once('change:data', this.render, this);
     this.add_related_model(this._dataviewModel);

--- a/src/widgets/time-series/torque-header-view.js
+++ b/src/widgets/time-series/torque-header-view.js
@@ -11,21 +11,20 @@ module.exports = cdb.core.View.extend({
   initialize: function () {
     this._dataviewModel = this.options.dataviewModel;
     this._torqueLayerModel = this.options.torqueLayerModel;
-    this._torqueLayerModel.bind('change:renderRange', this._onRenderRangeChange, this);
-    this.add_related_model(this._torqueLayerModel);
+    this._rangeFilter = this._dataviewModel.filter;
 
-    this._setHasSelectedRange();
+    this._rangeFilter.bind('change', this.render, this);
+    this.add_related_model(this._rangeFilter);
   },
 
   render: function () {
     this.clearSubViews();
 
-    if (this._hasRenderRange) {
+    if (!this._rangeFilter.isEmpty()) {
       this.el.classList.add('CDB-Widget-contentSpaced');
       this._appendView(
         new TorqueRenderRangeInfoView({
-          dataviewModel: this._dataviewModel,
-          torqueLayerModel: this._torqueLayerModel
+          dataviewModel: this._dataviewModel
         })
       );
       this._appendView(
@@ -48,19 +47,6 @@ module.exports = cdb.core.View.extend({
     }
 
     return this;
-  },
-
-  _onRenderRangeChange: function () {
-    var prev = this._hasRenderRange;
-    this._setHasSelectedRange();
-    if (prev !== this._hasRenderRange) {
-      this.render();
-    }
-  },
-
-  _setHasSelectedRange: function () {
-    var r = this._torqueLayerModel.get('renderRange');
-    this._hasRenderRange = r && r.start !== r.end;
   },
 
   _appendView: function (view) {

--- a/src/widgets/time-series/torque-histogram-view.js
+++ b/src/widgets/time-series/torque-histogram-view.js
@@ -26,21 +26,25 @@ module.exports = cdb.core.View.extend({
     if (!this.options.torqueLayerModel) throw new Error('torqeLayerModel is required');
     if (!this.options.rangeFilter) throw new Error('rangeFilter is required');
 
-    this._rangeFilter = this.options.rangeFilter;
-    this._torqueLayerModel = this.options.torqueLayerModel;
-    this._torqueLayerModel.bind('change:renderRange', this._onRenderRangeChanged, this);
-    this._torqueLayerModel.bind('change:steps change:start change:end', this._reSelectRange, this);
-    this.add_related_model(this._torqueLayerModel);
-
     this._dataviewModel = this.options.dataviewModel;
-    this._dataviewModel.bind('change:data', this._onChangeData, this);
-    this.add_related_model(this._dataviewModel);
+    this._rangeFilter = this.options.rangeFilter;
+    this._originalData = this._dataviewModel.getUnfilteredDataModel();
+    this._torqueLayerModel = this.options.torqueLayerModel;
+    this._initBinds();
   },
 
   render: function () {
     this.clearSubViews();
     this._createHistogramView();
     return this;
+  },
+
+  _initBinds: function () {
+    this._torqueLayerModel.bind('change:renderRange', this._onRenderRangeChanged, this);
+    this._torqueLayerModel.bind('change:steps change:start change:end', this._reSelectRange, this);
+    this.add_related_model(this._torqueLayerModel);
+    this._dataviewModel.bind('change:data', this._onChangeData, this);
+    this.add_related_model(this._dataviewModel);
   },
 
   _createHistogramView: function () {
@@ -60,6 +64,7 @@ module.exports = cdb.core.View.extend({
       hasHandles: true,
       height: this.defaults.histogramChartHeight,
       data: this._dataviewModel.getData(),
+      originalData: this._originalData,
       displayShadowBars: true
     });
 

--- a/src/widgets/time-series/torque-render-range-info-view.js
+++ b/src/widgets/time-series/torque-render-range-info-view.js
@@ -9,31 +9,39 @@ var template = require('./torque-render-range-info.tpl');
 module.exports = cdb.core.View.extend({
   initialize: function () {
     this._dataviewModel = this.options.dataviewModel;
-    this._torqueLayerModel = this.options.torqueLayerModel;
-    this._torqueLayerModel.bind('change:renderRange', this.render, this);
-    this.add_related_model(this._torqueLayerModel);
+    this._rangeFilter = this._dataviewModel.filter;
+    this._setupScales();
+    this._initBinds();
+  },
 
+  render: function () {
+    this.$el.html(template({
+      timeFormatter: this._timeFormatter,
+      dateFormatter: this._dateFormatter,
+      startDate: new Date(this._scale.invert(this._rangeFilter.get('min'))),
+      endDate: new Date(this._scale.invert(this._rangeFilter.get('max')))
+    }));
+
+    return this;
+  },
+
+  _initBinds: function () {
+    this._rangeFilter.bind('change', this.render, this);
+    this.add_related_model(this._rangeFilter);
+  },
+
+  _setupScales: function () {
     var data = this._dataviewModel.get('data');
+    var start = this._dataviewModel.get('start');
+    var end = this._dataviewModel.get('end');
+
     this._scale = d3.time.scale()
       .domain([data[0].start * 1000, data[data.length - 1].end * 1000])
       .nice()
-      .range([0, this._dataviewModel.get('bins')]);
+      .range([start, end]);
 
     // for format rules see https://github.com/mbostock/d3/wiki/Time-Formatting
     this._timeFormatter = d3.time.format('%H:%M');
     this._dateFormatter = d3.time.format('%x');
-  },
-
-  render: function () {
-    var renderRange = this._torqueLayerModel.get('renderRange');
-
-    this.$el.html(template({
-      timeFormatter: this._timeFormatter,
-      dateFormatter: this._dateFormatter,
-      startDate: new Date(this._scale.invert(renderRange.start)),
-      endDate: new Date(this._scale.invert(renderRange.end))
-    }));
-
-    return this;
   }
 });


### PR DESCRIPTION
Basically, after [this change](https://github.com/CartoDB/cartodb.js/pull/1181) in CartoDB.js, there is a new way to obtain all the data of the widget. That means we need to change several things in the histogram `content-view` and `chart` classes. I've tried to keep things as they are and only touch affected parts. I'd like to know your opinion @javierarce before keep going.

cc @viddo @javisantana 

Pending things:
- [x] Review tests.
- [x] Add new tests.
- [x] Review the impact over time series/torque widget.
- [x] Review static time-slider widget (fixes #195).
- [x] Review torque info when it is selected (fixes #277).

Overall, fixes https://github.com/CartoDB/cartodb.js/issues/1179.

CR: @javierarce 