### PR TITLE
Don't take into account layer visibility in order to show widget view

### DIFF
--- a/src/widgets/widget-view.js
+++ b/src/widgets/widget-view.js
@@ -30,10 +30,6 @@ module.exports = cdb.core.View.extend({
     }
 
     this._appendView(this.options.contentView);
-
-    // Show or hide the widget depending on the layer visibility
-    this._setVisible(this.model.dataviewModel.layer.get('visible'));
-
     return this;
   },
 

--- a/src/widgets/widget-view.js
+++ b/src/widgets/widget-view.js
@@ -14,10 +14,7 @@ module.exports = cdb.core.View.extend({
   },
 
   initialize: function () {
-    if (this.model.dataviewModel) {
-      this.model.dataviewModel.layer.bind('change:visible', this._onChangeLayerVisible, this);
-      this.listenTo(this.model, 'destroy', this.clean);
-    }
+    this.listenTo(this.model, 'destroy', this.clean);
   },
 
   render: function () {
@@ -43,14 +40,5 @@ module.exports = cdb.core.View.extend({
   _appendView: function (view) {
     this.$el.append(view.render().el);
     this.addView(view);
-  },
-
-  _setVisible: function (visible) {
-    this.$el.toggle(visible);
-  },
-
-  _onChangeLayerVisible: function (layer) {
-    // !! to force a boolean value, so only a true value actually shows the view
-    this._setVisible(!!layer.get('visible'));
   }
 });


### PR DESCRIPTION
As we decided when we talked about necessary analysis use cases, if a layer is not visible, widgets can be added and they will be visible.
cc @javierarce @alonsogarciapablo @rochoa  