### PR TITLE
Autostyle fixes

### DIFF
--- a/spec/widgets/auto-style/category.spec.js
+++ b/spec/widgets/auto-style/category.spec.js
@@ -15,17 +15,17 @@ describe('src/widgets/auto-style/category', function () {
   describe('.getStyle', function () {
     it('should generate the right styles when layer has polygons', function () {
       this.layer.getGeometryType.and.returnValue('polygon');
-      expect(this.categoryAutoStyler.getStyle().replace(/\s/g, '')).toEqual('#layer{polygon-fill:#CCC;polygon-opacity:0.6;line-color:#FFF;line-width:0.3;line-opacity:0.3;[something=\'a\']{polygon-fill:#CCC;}[something=\'b\']{polygon-fill:#CCC;}[something=\'c\']{polygon-fill:#CCC;}}');
+      expect(this.categoryAutoStyler.getStyle().replace(/\s/g, '')).toEqual('#layer{polygon-fill:#E1C221;polygon-opacity:0.6;line-color:#FFF;line-width:0.3;line-opacity:0.3;[something=\'a\']{polygon-fill:#E1C221;}[something=\'b\']{polygon-fill:#E1C221;}[something=\'c\']{polygon-fill:#E1C221;}}');
     });
 
     it('should generate the right styles when layer has points', function () {
       this.layer.getGeometryType.and.returnValue('marker');
-      expect(this.categoryAutoStyler.getStyle().replace(/\s/g, '')).toEqual('#layer{marker-width:10;marker-fill-opacity:0.8;marker-fill:#CCC;marker-line-color:#fff;marker-allow-overlap:true;marker-line-width:0.3;marker-line-opacity:0.8;[something=\'a\']{marker-fill:#CCC;}[something=\'b\']{marker-fill:#CCC;}[something=\'c\']{marker-fill:#CCC;}}');
+      expect(this.categoryAutoStyler.getStyle().replace(/\s/g, '')).toEqual('#layer{marker-width:10;marker-fill-opacity:0.8;marker-fill:#E1C221;marker-line-color:#fff;marker-allow-overlap:true;marker-line-width:0.3;marker-line-opacity:0.8;[something=\'a\']{marker-fill:#E1C221;}[something=\'b\']{marker-fill:#E1C221;}[something=\'c\']{marker-fill:#E1C221;}}');
     });
 
     it('should generate the right styles when layer has lines', function () {
       this.layer.getGeometryType.and.returnValue('line');
-      expect(this.categoryAutoStyler.getStyle().replace(/\s/g, '')).toEqual('#layer{line-color:#CCC;line-width:0.3;line-opacity:0.3;[something=\'a\']{line-color:#CCC;}[something=\'b\']{line-color:#CCC;}[something=\'c\']{line-color:#CCC;}}');
+      expect(this.categoryAutoStyler.getStyle().replace(/\s/g, '')).toEqual('#layer{line-color:#E1C221;line-width:0.3;line-opacity:0.3;[something=\'a\']{line-color:#E1C221;}[something=\'b\']{line-color:#E1C221;}[something=\'c\']{line-color:#E1C221;}}');
     });
   });
 });

--- a/spec/widgets/auto-style/histogram.js
+++ b/spec/widgets/auto-style/histogram.js
@@ -19,7 +19,7 @@ describe('src/widgets/auto-style/histogram', function () {
 
     it('should generate the right styles when layer has points', function () {
       this.layer.getGeometryType.and.returnValue('marker');
-      expect(this.histogramAutoStyler.getStyle().replace(/\s/g, '').indexOf('#layer{marker-width:ramp([something]')).not.toBeLessThan(0);
+      expect(this.histogramAutoStyler.getStyle().replace(/\s/g, '')).toEqual('#layer{marker-width:ramp([something],1,20,undefined);marker-fill-opacity:0.8;marker-fill:#000;marker-line-color:#fff;marker-allow-overlap:true;marker-line-width:0.3;marker-line-opacity:0.8;}');
     });
 
     it('should generate the right styles when layer has lines', function () {

--- a/spec/widgets/category/category-colors.spec.js
+++ b/spec/widgets/category/category-colors.spec.js
@@ -25,7 +25,7 @@ describe('widgets/category/category-colors', function () {
     it('should unset color<>category if that category is not present in the new data', function () {
       this.model.updateData(['ES', 'IT', 'PT', 'FR', 'AND', 'LUX', 'SUZ', 'SWD']);
       var color = this.model.getColorByCategory('PT');
-      expect(this.model.getColorByCategory('PT')).not.toBe('#CCC');
+      expect(this.model.getColorByCategory('PT')).not.toBe('#E1C221');
       this.model.updateData(['FR', 'AND']);
       expect(this.model.getCategoryByColor(color)).toBe(null);
     });
@@ -42,7 +42,7 @@ describe('widgets/category/category-colors', function () {
       var color = this.model.getColorByCategory('IT');
       this.model.updateData(['ES', 'PT', 'FR', 'AND', 'NOR']);
       expect(this.model.getColorByCategory('NOR')).toBe(color);
-      expect(this.model.getColorByCategory('IT')).toBe('#CCC');
+      expect(this.model.getColorByCategory('IT')).toBe('#E1C221');
     });
 
     it('should not change colors if data changes but there is no new categories', function () {
@@ -60,15 +60,15 @@ describe('widgets/category/category-colors', function () {
   describe('getColorByCategory', function () {
     it('should return the color from a category', function () {
       this.model.updateData(_generateData(7));
-      expect(this.model.getColorByCategory('CAT3')).not.toBe('#CCC');
-      expect(this.model.getColorByCategory('CAT2')).not.toBe('#CCC');
+      expect(this.model.getColorByCategory('CAT3')).not.toBe('#E1C221');
+      expect(this.model.getColorByCategory('CAT2')).not.toBe('#E1C221');
     });
 
     it('should return a default color if that category has not a color set', function () {
       this.model.updateData(_generateData(9));
-      expect(this.model.getColorByCategory('CAT8')).toBe('#CCC');
-      expect(this.model.getColorByCategory('CAT9')).toBe('#CCC');
-      expect(this.model.getColorByCategory('@')).toBe('#CCC');
+      expect(this.model.getColorByCategory('CAT8')).toBe('#E1C221');
+      expect(this.model.getColorByCategory('CAT9')).toBe('#E1C221');
+      expect(this.model.getColorByCategory('@')).toBe('#E1C221');
     });
   });
 

--- a/src/widgets/auto-style/auto-styler.js
+++ b/src/widgets/auto-style/auto-styler.js
@@ -41,9 +41,9 @@ AutoStyler.STYLE_TEMPLATE = {
 };
 
 AutoStyler.MAPNIK_MAPPING = {
-  polygon: 'polygon',
-  marker: 'point',
-  line: 'linestring'
+  polygon: 3,
+  marker: 1,
+  line: 2
 };
 
 module.exports = AutoStyler;

--- a/src/widgets/auto-style/auto-styler.js
+++ b/src/widgets/auto-style/auto-styler.js
@@ -8,7 +8,7 @@ var AutoStyler = cdb.core.Model.extend({
   },
 
   _getLayerHeader: function (symbol) {
-    return '#' + this.dataviewModel.layer.get('layer_name') + '[mapnik-geometry-type=' + AutoStyler.MAPNIK_MAPPING[symbol] + ']{';
+    return '#' + this.dataviewModel.layer.get('layer_name').replace(/\s*/g, '') + '[mapnik-geometry-type=' + AutoStyler.MAPNIK_MAPPING[symbol] + ']{';
   }
 
 });

--- a/src/widgets/auto-style/category-colors.js
+++ b/src/widgets/auto-style/category-colors.js
@@ -5,7 +5,7 @@ var colorScales = [['#2CA095', '#E5811B', '#4A4DBA', '#AD2BAD', '#559030', '#E1C
                    ['rgb(127,201,127)', 'rgb(190,174,212)', 'rgb(253,192,134)', 'rgb(255,255,153)', 'rgb(56,108,176)', 'rgb(240,2,127)'],
                    ['rgb(141,211,199)', 'rgb(255,255,179)', 'rgb(190,186,218)', 'rgb(251,128,114)', 'rgb(128,177,211)', 'rgb(253,180,98)']
                   ]; // Demo colors
-var defaultColor = '#CCC';
+var defaultColor = '#E1C221';
 
 /**
  *  Class to set categories to each color

--- a/src/widgets/auto-style/category-colors.js
+++ b/src/widgets/auto-style/category-colors.js
@@ -56,7 +56,7 @@ CategoryColors.prototype.getColorByCategory = function (category) {
       return i;
     }
   }
-  return defaultColor;
+  return Object.keys(this.colors)[Object.keys(this.colors).length - 1];
 };
 
 CategoryColors.prototype.getCategoryByColor = function (color) {

--- a/src/widgets/auto-style/category-colors.js
+++ b/src/widgets/auto-style/category-colors.js
@@ -5,7 +5,6 @@ var colorScales = [['#2CA095', '#E5811B', '#4A4DBA', '#AD2BAD', '#559030', '#E1C
                    ['rgb(127,201,127)', 'rgb(190,174,212)', 'rgb(253,192,134)', 'rgb(255,255,153)', 'rgb(56,108,176)', 'rgb(240,2,127)'],
                    ['rgb(141,211,199)', 'rgb(255,255,179)', 'rgb(190,186,218)', 'rgb(251,128,114)', 'rgb(128,177,211)', 'rgb(253,180,98)']
                   ]; // Demo colors
-var defaultColor = '#E1C221';
 
 /**
  *  Class to set categories to each color

--- a/src/widgets/auto-style/histogram.js
+++ b/src/widgets/auto-style/histogram.js
@@ -29,7 +29,7 @@ var HistogramAutoStyler = AutoStyler.extend({
     if (geometryType === 'polygon') {
       style = style.replace('{{defaultColor}}', 'ramp([{{column}}], colorbrewer({{color}}, {{bins}}))');
     } else if (geometryType === 'marker') {
-      style = style.replace('{{markerWidth}}', 'ramp([{{column}}], {{min}}, {{max}}), {{bins}})');
+      style = style.replace('{{markerWidth}}', 'ramp([{{column}}], {{min}}, {{max}}, {{bins}})');
     } else {
       style = style.replace('{{defaultColor}}', '#000');
     }

--- a/src/widgets/category/category-widget-model.js
+++ b/src/widgets/category/category-widget-model.js
@@ -54,6 +54,7 @@ module.exports = WidgetModel.extend({
   },
 
   autoStyle: function () {
+    this.autoStyler.colors.updateData(this.dataviewModel.get('allCategoryNames'));
     var style = this.autoStyler.getStyle();
     this.dataviewModel.layer.set('cartocss', style);
     this.set('autoStyle', true);
@@ -114,9 +115,8 @@ module.exports = WidgetModel.extend({
   },
 
   _onDataviewAllCategoryNamesChange: function (m, names) {
-    this.autoStyler.colors.updateData(names);
-    if (this.isAutoStyle()) {
-      this.autoStyle();
+    if (!this.isAutoStyle()) {
+      this.autoStyler.colors.updateData(names);
     }
   },
 


### PR DESCRIPTION
@javisantana @rochoa 

- Corrects typo in turbocartocss string for histogram-markers in vector (fixes #318).
- Prevents maps from reinstantiating when category auto style is on (fixes #319).
- Freezes assignment of new colours when auto style is on with category.
- Uses indices instead of geometry type names (fixes #316).