### PR TITLE
Export reference to the dashboard view.

### DIFF
--- a/spec/api/dashboard.spec.js
+++ b/spec/api/dashboard.spec.js
@@ -1,4 +1,6 @@
+var Backbone = require('backbone');
 var Dashboard = require('../../src/api/dashboard');
+var DashboardView = require('../../src/dashboard-view');
 var URLHelper = require('../../src/api/url-helper');
 describe('dashboard', function () {
   beforeEach(function () {
@@ -22,5 +24,17 @@ describe('dashboard', function () {
     spyOn(URLHelper, 'getLocalURL').and.returnValue(url);
     var correctState = { 1: { collapsed: true }, 3: { collapsed: true }, 5: { autoStyle: true } };
     expect(URLHelper.getStateFromCurrentURL()).toEqual(correctState);
+  });
+
+  it('should return dashboard view', function () {
+    var view = new DashboardView({
+      widgets: new Backbone.Collection(),
+      model: new cdb.core.Model({
+        renderMenu: true
+      })
+    });
+    spyOn(this.dashboard, 'getView').and.returnValue(view);
+    expect(this.dashboard.getView().render().el).toBeDefined();
+    expect(this.dashboard.getView().render().$('.js-map-wrapper').length).toBe(1);
   });
 });

--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -8,6 +8,13 @@ function Dashboard (dashboard) {
 Dashboard.prototype = {
 
   /**
+   * @return {View} used in the dashboard
+   */
+  getView: function () {
+    return this._dashboard.dashboardView;
+  },
+
+  /**
    * @return {Map} the map used in the dashboard
    */
   getMap: function () {


### PR DESCRIPTION
In https://github.com/CartoDB/cartodb/issues/7445, we need a public reference to the view, in order to change the background color of the dashboard view when we are editing.

cc @xavijam 