### PR TITLE
Only encodes state string once

### DIFF
--- a/src/api/url-helper.js
+++ b/src/api/url-helper.js
@@ -6,7 +6,7 @@ module.exports = {
     var thisURL = new URI(this.getLocalURL());
     thisURL.removeQuery('state');
     if (!_.isEmpty(state)) {
-      var statesString = encodeURIComponent(JSON.stringify(state));
+      var statesString = JSON.stringify(state);
       thisURL.setQuery('state', statesString);
     }
     return thisURL.toString();


### PR DESCRIPTION
State strings in URLs seem to be URLencoded twice, because the library that we use to parse URLs already does the encoding internally. I'm just removing our call here.
@xavijam 