### PR TITLE
Uses layerX instead of offsetX to calculate clicked bar index

### DIFF
--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -683,7 +683,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _getBarIndex: function () {
-    var x = d3.event.sourceEvent.offsetX;
+    var x = d3.event.sourceEvent.layerX;
     return Math.floor(x / this.barWidth);
   },
 


### PR DESCRIPTION
Using offsetX was causing the `_getBarIndex` to return always 0.

Fixes #373 

CR @javierarce 🙌 