### PR TITLE
Keeps marker widths on autostyle 

### DIFF
--- a/spec/widgets/auto-style/histogram.js
+++ b/spec/widgets/auto-style/histogram.js
@@ -8,7 +8,7 @@ describe('src/widgets/auto-style/histogram', function () {
     });
 
     this.dataview.getDistributionType = jasmine.createSpy('disttype').and.returnValue('F');
-    this.layer = this.dataview.layer = jasmine.createSpyObj('layer', ['getGeometryType']);
+    this.layer = this.dataview.layer = jasmine.createSpyObj('layer', ['getGeometryType', 'get']);
     this.histogramAutoStyler = new HistogramAutoStyler(this.dataview);
   });
 
@@ -21,6 +21,12 @@ describe('src/widgets/auto-style/histogram', function () {
     it('should generate the right styles when layer has points', function () {
       this.layer.getGeometryType.and.returnValue('marker');
       expect(this.histogramAutoStyler.getStyle().replace(/\s/g, '').indexOf('{{')).toBeLessThan(0);
+    });
+
+    it('should preserve the previous marker widths if they were formed with turbocarto', function () {
+      this.layer.getGeometryType.and.returnValue('marker');
+      this.layer.get.and.returnValue('#layer {  marker-line-width: 0.5;  marker-line-color: #1e1e1e;  marker-line-opacity: 1;  marker-width: 3;  marker-fill: #b7f2de;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
+      expect(this.histogramAutoStyler.getStyle().indexOf('ramp([something], cartocolor(')).not.toBeLessThan(0);
     });
 
     it('should generate the right styles when layer has lines', function () {

--- a/src/widgets/auto-style/auto-styler.js
+++ b/src/widgets/auto-style/auto-styler.js
@@ -16,10 +16,10 @@ var AutoStyler = cdb.core.Model.extend({
   getPreservedWidth: function () {
     var startingStyle = this.layer.get && this.layer.get('cartocss');
     if (startingStyle) {
-      var originalWidth = startingStyle.match(/marker-width:.*;/g);
+      var originalWidth = startingStyle.match(/marker-width:.*?;\s/g);
       if (originalWidth) {
         if (originalWidth.length > 1) {
-          return null
+          return null;
         } else {
           originalWidth = originalWidth[0].replace('marker-width:', '').replace(';', '');
         }

--- a/src/widgets/auto-style/auto-styler.js
+++ b/src/widgets/auto-style/auto-styler.js
@@ -14,9 +14,10 @@ var AutoStyler = cdb.core.Model.extend({
   },
 
   getPreservedWidth: function () {
+    var originalWidth;
     var startingStyle = this.layer.get && this.layer.get('cartocss');
     if (startingStyle) {
-      var originalWidth = startingStyle.match(/marker-width:.*?;\s/g);
+      originalWidth = startingStyle.match(/marker-width:.*?;\s/g);
       if (originalWidth) {
         if (originalWidth.length > 1) {
           return null;

--- a/src/widgets/auto-style/auto-styler.js
+++ b/src/widgets/auto-style/auto-styler.js
@@ -11,6 +11,21 @@ var AutoStyler = cdb.core.Model.extend({
 
   _getLayerHeader: function (symbol) {
     return '#' + this.dataviewModel.layer.get('layer_name').replace(/\s*/g, '') + '[mapnik-geometry-type=' + AutoStyler.MAPNIK_MAPPING[symbol] + ']{';
+  },
+
+  getPreservedWidth: function () {
+    var startingStyle = this.layer.get && this.layer.get('cartocss');
+    if (startingStyle) {
+      var originalWidth = startingStyle.match(/marker-width:.*;/g);
+      if (originalWidth) {
+        if (originalWidth.length > 1) {
+          return null
+        } else {
+          originalWidth = originalWidth[0].replace('marker-width:', '').replace(';', '');
+        }
+      }
+    }
+    return originalWidth;
   }
 
 });

--- a/src/widgets/auto-style/category.js
+++ b/src/widgets/auto-style/category.js
@@ -1,6 +1,8 @@
 var AutoStyler = require('./auto-styler');
 var CategoryAutoStyler = AutoStyler.extend({
   getStyle: function () {
+    var startingStyle = this.layer.get('meta').cartocss;
+    var originalWidth = startingStyle.match(/marker-width:.*ramp.*;/g).replace('marker-width:', '');
     var style = '';
     var defColor = this.colors.getColorByCategory('Other');
     var stylesByGeometry = this.STYLE_TEMPLATE;
@@ -17,9 +19,13 @@ var CategoryAutoStyler = AutoStyler.extend({
           .replace('{{ramp}}', this._generateCategoryRamp(symbol));
       }
     }
-    return style
-      .replace(/{{defaultColor}}/g, defColor)
-      .replace('{{markerWidth}}', 7);
+    style = style.replace(/{{defaultColor}}/g, defColor);
+    if (originalWidth) {
+      style = style.replace('{{markerWidth}}', originalWidth);
+    } else {
+      style = style.replace('{{markerWidth}}', 7);
+    }
+    return style;
   },
 
   _generateCategoryRamp: function (sym) {

--- a/src/widgets/auto-style/category.js
+++ b/src/widgets/auto-style/category.js
@@ -1,8 +1,8 @@
 var AutoStyler = require('./auto-styler');
 var CategoryAutoStyler = AutoStyler.extend({
   getStyle: function () {
-    var startingStyle = this.layer.get('meta').cartocss;
-    var originalWidth = startingStyle.match(/marker-width:.*ramp.*;/g).replace('marker-width:', '');
+    var startingStyle = this.layer.get('cartocss');
+    var originalWidth = startingStyle.match(/marker-width:.*;/g)[0].replace('marker-width:', '').replace(';', '');
     var style = '';
     var defColor = this.colors.getColorByCategory('Other');
     var stylesByGeometry = this.STYLE_TEMPLATE;

--- a/src/widgets/auto-style/category.js
+++ b/src/widgets/auto-style/category.js
@@ -2,18 +2,7 @@ var AutoStyler = require('./auto-styler');
 var _ = require('underscore');
 var CategoryAutoStyler = AutoStyler.extend({
   getStyle: function () {
-    var preserveWidth = true;
-    var startingStyle = this.layer.get && this.layer.get('cartocss');
-    if (startingStyle) {
-      var originalWidth = startingStyle.match(/marker-width:.*;/g);
-      if (originalWidth) {
-        if (originalWidth.length > 1) {
-          preserveWidth = false;
-        } else {
-          originalWidth = originalWidth[0].replace('marker-width:', '').replace(';', '');
-        }
-      }
-    }
+    var preservedWidth = this.getPreservedWidth();
     var style = '';
     var defColor = this.colors.getColorByCategory('Other');
     var stylesByGeometry = this.STYLE_TEMPLATE;
@@ -31,8 +20,8 @@ var CategoryAutoStyler = AutoStyler.extend({
       }
     }
     style = style.replace(/{{defaultColor}}/g, defColor);
-    if (preserveWidth && !_.isEmpty(originalWidth)) {
-      style = style.replace('{{markerWidth}}', originalWidth);
+    if (!_.isEmpty(preservedWidth)) {
+      style = style.replace('{{markerWidth}}', preservedWidth);
     } else {
       style = style.replace('{{markerWidth}}', 7);
     }

--- a/src/widgets/auto-style/category.js
+++ b/src/widgets/auto-style/category.js
@@ -3,12 +3,16 @@ var _ = require('underscore');
 var CategoryAutoStyler = AutoStyler.extend({
   getStyle: function () {
     var preserveWidth = true;
-    var startingStyle = this.layer.get('cartocss');
-    var originalWidth = startingStyle.match(/marker-width:.*;/g);
-    if (originalWidth.length > 1) {
-      preserveWidth = false;
-    } else {
-      originalWidth = originalWidth[0].replace('marker-width:', '').replace(';', '');
+    var startingStyle = this.layer.get && this.layer.get('cartocss');
+    if (startingStyle) {
+      var originalWidth = startingStyle.match(/marker-width:.*;/g);
+      if (originalWidth) {
+        if (originalWidth.length > 1) {
+          preserveWidth = false;
+        } else {
+          originalWidth = originalWidth[0].replace('marker-width:', '').replace(';', '');
+        }
+      }
     }
     var style = '';
     var defColor = this.colors.getColorByCategory('Other');

--- a/src/widgets/auto-style/category.js
+++ b/src/widgets/auto-style/category.js
@@ -1,4 +1,5 @@
 var AutoStyler = require('./auto-styler');
+var _ = require('underscore');
 var CategoryAutoStyler = AutoStyler.extend({
   getStyle: function () {
     var preserveWidth = true;
@@ -30,7 +31,7 @@ var CategoryAutoStyler = AutoStyler.extend({
       }
     }
     style = style.replace(/{{defaultColor}}/g, defColor);
-    if (preserveWidth) {
+    if (preserveWidth && !_.isEmpty(originalWidth)) {
       style = style.replace('{{markerWidth}}', originalWidth);
     } else {
       style = style.replace('{{markerWidth}}', 7);

--- a/src/widgets/auto-style/category.js
+++ b/src/widgets/auto-style/category.js
@@ -1,8 +1,15 @@
 var AutoStyler = require('./auto-styler');
+var _ = require('underscore');
 var CategoryAutoStyler = AutoStyler.extend({
   getStyle: function () {
+    var preserveWidth = true;
     var startingStyle = this.layer.get('cartocss');
-    var originalWidth = startingStyle.match(/marker-width:.*;/g)[0].replace('marker-width:', '').replace(';', '');
+    var originalWidth = startingStyle.match(/marker-width:.*;/g);
+    if (originalWidth.length > 1) {
+      preserveWidth = false;
+    } else {
+      originalWidth = originalWidth[0].replace('marker-width:', '').replace(';', '');
+    }
     var style = '';
     var defColor = this.colors.getColorByCategory('Other');
     var stylesByGeometry = this.STYLE_TEMPLATE;
@@ -20,7 +27,7 @@ var CategoryAutoStyler = AutoStyler.extend({
       }
     }
     style = style.replace(/{{defaultColor}}/g, defColor);
-    if (originalWidth) {
+    if (preserveWidth && _.isNumber(originalWidth)) {
       style = style.replace('{{markerWidth}}', originalWidth);
     } else {
       style = style.replace('{{markerWidth}}', 7);

--- a/src/widgets/auto-style/category.js
+++ b/src/widgets/auto-style/category.js
@@ -1,5 +1,4 @@
 var AutoStyler = require('./auto-styler');
-var _ = require('underscore');
 var CategoryAutoStyler = AutoStyler.extend({
   getStyle: function () {
     var preserveWidth = true;
@@ -31,7 +30,7 @@ var CategoryAutoStyler = AutoStyler.extend({
       }
     }
     style = style.replace(/{{defaultColor}}/g, defColor);
-    if (preserveWidth && _.isNumber(originalWidth)) {
+    if (preserveWidth) {
       style = style.replace('{{markerWidth}}', originalWidth);
     } else {
       style = style.replace('{{markerWidth}}', 7);

--- a/src/widgets/auto-style/histogram.js
+++ b/src/widgets/auto-style/histogram.js
@@ -31,7 +31,7 @@ var HistogramAutoStyler = AutoStyler.extend({
       if (shape === 'F') {
         style = style.replace('{{defaultColor}}', 'ramp([{{column}}], cartocolor(Sunset3, {{bins}})), quantiles');
       } else if (shape === 'L' || shape === 'J') {
-        style = style.replace('{{defaultColor}}', 'ramp([{{column}}], cartocolor(Sunset2, {{bins}}), headstails)');
+        style = style.replace('{{defaultColor}}', 'ramp([{{column}}], cartocolor(Sunset2, {{bins}}), headtails)');
       } else if (shape === 'A') {
         style = style.replace('{{defaultColor}}', 'ramp([{{column}}], cartocolor(Geyser, {{bins}})), quantiles');
       } else if (shape === 'C' || shape === 'U') {
@@ -44,7 +44,7 @@ var HistogramAutoStyler = AutoStyler.extend({
         style = style.replace('{{defaultColor}}', 'ramp([{{column}}], cartocolor(RedOr1, {{bins}})), quantiles')
                      .replace('{{markerWidth}}', '7');
       } else if (shape === 'L' || shape === 'J') {
-        style = style.replace('{{defaultColor}}', 'ramp([{{column}}], cartocolor(Sunset2, {{bins}}), headstails)')
+        style = style.replace('{{defaultColor}}', 'ramp([{{column}}], cartocolor(Sunset2, {{bins}}), headtails)')
                      .replace('{{markerWidth}}', '7');
       } else if (shape === 'A') {
         style = style.replace('{{defaultColor}}', 'ramp([{{column}}], cartocolor(Geyser, {{bins}})), quantiles')

--- a/src/widgets/auto-style/histogram.js
+++ b/src/widgets/auto-style/histogram.js
@@ -2,18 +2,7 @@ var AutoStyler = require('./auto-styler');
 var _ = require('underscore');
 var HistogramAutoStyler = AutoStyler.extend({
   getStyle: function () {
-    var preserveWidth = true;
-    var startingStyle = this.layer.get && (this.layer.get('cartocss') || this.layer.get('meta').cartocss);
-    if (startingStyle) {
-      var originalWidth = startingStyle.match(/marker-width:.*;/g);
-      if (originalWidth) {
-        if (originalWidth.length > 1) {
-          preserveWidth = false;
-        } else {
-          originalWidth = originalWidth[0].replace('marker-width:', '').replace(';', '');
-        }
-      }
-    }
+    var preservedWidth = this.getPreservedWidth();
     var style = '';
     var colors = ['YlGnBu', 'Greens', 'Reds', 'Blues'];
     var color = colors[Math.floor(Math.random() * colors.length)];
@@ -28,8 +17,8 @@ var HistogramAutoStyler = AutoStyler.extend({
           .replace('{{layername}}', this._getLayerHeader(symbol));
       }
     }
-    if (preserveWidth && !_.isEmpty(originalWidth)) {
-      style = style.replace('{{markerWidth}}', originalWidth);
+    if (!_.isEmpty(preservedWidth)) {
+      style = style.replace('{{markerWidth}}', preservedWidth);
     }
     return style.replace(/{{column}}/g, this.dataviewModel.get('column'))
       .replace(/{{bins}}/g, this.dataviewModel.get('bins'))

--- a/src/widgets/auto-style/histogram.js
+++ b/src/widgets/auto-style/histogram.js
@@ -1,4 +1,5 @@
 var AutoStyler = require('./auto-styler');
+var _ = require('underscore');
 var HistogramAutoStyler = AutoStyler.extend({
   getStyle: function () {
     var preserveWidth = true;
@@ -27,7 +28,7 @@ var HistogramAutoStyler = AutoStyler.extend({
           .replace('{{layername}}', this._getLayerHeader(symbol));
       }
     }
-    if (preserveWidth) {
+    if (preserveWidth && !_.isEmpty(originalWidth)) {
       style = style.replace('{{markerWidth}}', originalWidth);
     }
     return style.replace(/{{column}}/g, this.dataviewModel.get('column'))

--- a/src/widgets/auto-style/histogram.js
+++ b/src/widgets/auto-style/histogram.js
@@ -1,5 +1,4 @@
 var AutoStyler = require('./auto-styler');
-var _ = require('underscore');
 var HistogramAutoStyler = AutoStyler.extend({
   getStyle: function () {
     var preserveWidth = true;

--- a/src/widgets/auto-style/histogram.js
+++ b/src/widgets/auto-style/histogram.js
@@ -1,6 +1,19 @@
 var AutoStyler = require('./auto-styler');
+var _ = require('underscore');
 var HistogramAutoStyler = AutoStyler.extend({
   getStyle: function () {
+    var preserveWidth = true;
+    var startingStyle = this.layer.get && (this.layer.get('cartocss') || this.layer.get('meta').cartocss);
+    if (startingStyle) {
+      var originalWidth = startingStyle.match(/marker-width:.*;/g);
+      if (originalWidth) {
+        if (originalWidth.length > 1) {
+          preserveWidth = false;
+        } else {
+          originalWidth = originalWidth[0].replace('marker-width:', '').replace(';', '');
+        }
+      }
+    }
     var style = '';
     var colors = ['YlGnBu', 'Greens', 'Reds', 'Blues'];
     var color = colors[Math.floor(Math.random() * colors.length)];
@@ -14,6 +27,9 @@ var HistogramAutoStyler = AutoStyler.extend({
         style += this._getHistGeometry(symbol)
           .replace('{{layername}}', this._getLayerHeader(symbol));
       }
+    }
+    if (preserveWidth) {
+      style = style.replace('{{markerWidth}}', originalWidth);
     }
     return style.replace(/{{column}}/g, this.dataviewModel.get('column'))
       .replace(/{{bins}}/g, this.dataviewModel.get('bins'))
@@ -41,17 +57,13 @@ var HistogramAutoStyler = AutoStyler.extend({
       }
     } else if (geometryType === 'marker') {
       if (shape === 'F') {
-        style = style.replace('{{defaultColor}}', 'ramp([{{column}}], cartocolor(RedOr1, {{bins}})), quantiles')
-                     .replace('{{markerWidth}}', '7');
+        style = style.replace('{{defaultColor}}', 'ramp([{{column}}], cartocolor(RedOr1, {{bins}})), quantiles');
       } else if (shape === 'L' || shape === 'J') {
-        style = style.replace('{{defaultColor}}', 'ramp([{{column}}], cartocolor(Sunset2, {{bins}}), headtails)')
-                     .replace('{{markerWidth}}', '7');
+        style = style.replace('{{defaultColor}}', 'ramp([{{column}}], cartocolor(Sunset2, {{bins}}), headtails)');
       } else if (shape === 'A') {
-        style = style.replace('{{defaultColor}}', 'ramp([{{column}}], cartocolor(Geyser, {{bins}})), quantiles')
-                     .replace('{{markerWidth}}', '7');
+        style = style.replace('{{defaultColor}}', 'ramp([{{column}}], cartocolor(Geyser, {{bins}})), quantiles)');
       } else if (shape === 'C' || shape === 'U') {
-        style = style.replace('{{defaultColor}}', 'ramp([{{column}}], cartocolor(BluYl1, {{bins}}), jenks)')
-                     .replace('{{markerWidth}}', '7');
+        style = style.replace('{{defaultColor}}', 'ramp([{{column}}], cartocolor(BluYl1, {{bins}}), jenks)');
       } else {
         style = style.replace('{{markerWidth}}', 'ramp([{{column}}], {{min}}, {{max}}, {{bins}})');
       }

--- a/src/widgets/auto-style/histogram.js
+++ b/src/widgets/auto-style/histogram.js
@@ -19,6 +19,8 @@ var HistogramAutoStyler = AutoStyler.extend({
     }
     if (!_.isEmpty(preservedWidth)) {
       style = style.replace('{{markerWidth}}', preservedWidth);
+    } else {
+      style = style.replace('{{markerWidth}}', 7);
     }
     return style.replace(/{{column}}/g, this.dataviewModel.get('column'))
       .replace(/{{bins}}/g, this.dataviewModel.get('bins'))


### PR DESCRIPTION
Notice that this applies to turbo-carto and static marker size rules, like the following:
```
marker-width: ramp([col],10, 30, 'jenks');
```
or
```
marker-width: 10;
```