### PR TITLE
Inverting the autostyle workflow so styles aren't rewritten, but modified.

### DIFF
--- a/spec/widgets/auto-style.spec.js
+++ b/spec/widgets/auto-style.spec.js
@@ -5,9 +5,7 @@ describe('auto-style', function () {
     var vis = specHelper.createDefaultVis();
     var layer = vis.map.layers.first();
     layer.restoreCartoCSS = jasmine.createSpy('restore');
-    layer.getGeometryType = function () {
-      return 'polygon';
-    };
+    layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
     this.dataviewModel = vis.dataviews.createCategoryModel(layer, {
       column: 'col'
     });
@@ -23,8 +21,8 @@ describe('auto-style', function () {
 
   it('should generate category ramps', function () {
     this.dataviewModel.set('allCategoryNames', ['manolo', 'jacinto', 'eustaquio']);
-    expect(this.autoStyler._generateCategoryRamp('marker').indexOf('marker-fill')).not.toBeLessThan(0);
-    expect(this.autoStyler._generateCategoryRamp('polygon').indexOf('polygon-fill')).not.toBeLessThan(0);
-    expect(this.autoStyler._generateCategoryRamp('line').indexOf('line-color')).not.toBeLessThan(0);
+    expect(this.autoStyler._generateCategoryRamp('marker-fill').indexOf('marker-fill')).not.toBeLessThan(0);
+    expect(this.autoStyler._generateCategoryRamp('polygon-fill').indexOf('polygon-fill')).not.toBeLessThan(0);
+    expect(this.autoStyler._generateCategoryRamp('line-color').indexOf('line-color')).not.toBeLessThan(0);
   });
 });

--- a/spec/widgets/auto-style/category.spec.js
+++ b/spec/widgets/auto-style/category.spec.js
@@ -1,30 +1,33 @@
+var specHelper = require('../../spec-helper');
 var CategoryAutoStyler = require('../../../src/widgets/auto-style/category.js');
 var Backbone = require('backbone');
 
 describe('src/widgets/auto-style/category', function () {
   beforeEach(function () {
+    var vis = specHelper.createDefaultVis();
+    var layer = vis.map.layers.first();
     this.dataview = new Backbone.Model({
       allCategoryNames: ['a', 'b', 'c'],
       column: 'something'
     });
-
-    this.layer = this.dataview.layer = jasmine.createSpyObj('layer', ['getGeometryType']);
+    this.layer = this.dataview.layer = layer;
     this.categoryAutoStyler = new CategoryAutoStyler(this.dataview);
   });
 
   describe('.getStyle', function () {
     it('should generate the right styles when layer has polygons', function () {
-      this.layer.getGeometryType.and.returnValue('polygon');
-      expect(this.categoryAutoStyler.getStyle().indexOf('[something=\'a\']{\npolygon-fill:')).not.toBeLessThan(0);
+      this.dataview.layer.set('initialStyle', '#layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1;  polygon-fill: #e49115;  polygon-fill-opacity: 0.9; }');
+      var style = this.categoryAutoStyler.getStyle();
+      expect(style.indexOf('[something=\'a\']{\npolygon-fill:')).not.toBeLessThan(0);
     });
 
     it('should generate the right styles when layer has points', function () {
-      this.layer.getGeometryType.and.returnValue('marker');
+      this.layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
       expect(this.categoryAutoStyler.getStyle().indexOf('[something=\'a\']{\nmarker-fill:')).not.toBeLessThan(0);
     });
 
     it('should generate the right styles when layer has lines', function () {
-      this.layer.getGeometryType.and.returnValue('line');
+      this.dataview.layer.set('initialStyle', '#layer {  line-width: 0.5;  line-color: #fcfafa;  line-opacity: 1; }');
       expect(this.categoryAutoStyler.getStyle().indexOf('[something=\'a\']{\nline-color:')).not.toBeLessThan(0);
     });
   });

--- a/spec/widgets/auto-style/histogram.js
+++ b/spec/widgets/auto-style/histogram.js
@@ -1,36 +1,33 @@
 var HistogramAutoStyler = require('../../../src/widgets/auto-style/histogram.js');
 var Backbone = require('backbone');
+var specHelper = require('../../spec-helper');
 
 describe('src/widgets/auto-style/histogram', function () {
   beforeEach(function () {
+    var vis = specHelper.createDefaultVis();
+    var layer = vis.map.layers.first();
     this.dataview = new Backbone.Model({
       column: 'something'
     });
 
     this.dataview.getDistributionType = jasmine.createSpy('disttype').and.returnValue('F');
-    this.layer = this.dataview.layer = jasmine.createSpyObj('layer', ['getGeometryType', 'get']);
+    this.layer = this.dataview.layer = layer;
     this.histogramAutoStyler = new HistogramAutoStyler(this.dataview);
   });
 
   describe('.getStyle', function () {
     it('should generate the right styles when layer has polygons', function () {
-      this.layer.getGeometryType.and.returnValue('polygon');
+      this.dataview.layer.set('initialStyle', '#layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1;  polygon-fill: #e49115;  polygon-fill-opacity: 0.9; }');
       expect(this.histogramAutoStyler.getStyle().replace(/\s/g, '').indexOf('{{')).toBeLessThan(0);
     });
 
     it('should generate the right styles when layer has points', function () {
-      this.layer.getGeometryType.and.returnValue('marker');
+      this.dataview.layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
       expect(this.histogramAutoStyler.getStyle().replace(/\s/g, '').indexOf('{{')).toBeLessThan(0);
     });
 
-    it('should preserve the previous marker widths if they were formed with turbocarto', function () {
-      this.layer.getGeometryType.and.returnValue('marker');
-      this.layer.get.and.returnValue('#layer {  marker-line-width: 0.5;  marker-line-color: #1e1e1e;  marker-line-opacity: 1;  marker-width: 3;  marker-fill: #b7f2de;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
-      expect(this.histogramAutoStyler.getStyle().indexOf('ramp([something], cartocolor(')).not.toBeLessThan(0);
-    });
-
     it('should generate the right styles when layer has lines', function () {
-      this.layer.getGeometryType.and.returnValue('line');
+      this.dataview.layer.set('initialStyle', '#layer {  line-width: 0.5;  line-color: #fcfafa;  line-opacity: 1; }');
       expect(this.histogramAutoStyler.getStyle().replace(/\s/g, '').indexOf('{{')).toBeLessThan(0);
     });
   });

--- a/spec/widgets/category/category-widget-model.spec.js
+++ b/spec/widgets/category/category-widget-model.spec.js
@@ -39,6 +39,7 @@ describe('widgets/category/category-widget-model', function () {
 
   describe('colors', function () {
     beforeEach(function () {
+      this.dataviewModel.layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
       spyOn(this.widgetModel.autoStyler.colors, 'updateData').and.callThrough();
       spyOn(this.widgetModel, 'autoStyle').and.callThrough();
     });

--- a/spec/widgets/category/search-title-view.spec.js
+++ b/spec/widgets/category/search-title-view.spec.js
@@ -13,6 +13,7 @@ describe('widgets/category/search-title-view', function () {
     this.dataviewModel = vis.dataviews.createCategoryModel(layer, {
       column: 'col'
     });
+    this.dataviewModel.layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
     this.widgetModel = new CategoryWidgetModel({}, {
       dataviewModel: this.dataviewModel
     });

--- a/src/widgets/auto-style/auto-styler.js
+++ b/src/widgets/auto-style/auto-styler.js
@@ -15,12 +15,16 @@ var AutoStyler = cdb.core.Model.extend({
 
   getPreservedWidth: function () {
     var originalWidth;
-    var startingStyle = this.layer.get && this.layer.get('cartocss');
+    var startingStyle = this.layer.get && (this.layer.get('cartocss') || this.layer.get('meta').cartocss);
     if (startingStyle) {
       originalWidth = startingStyle.match(/marker-width:.*?;\s/g);
       if (originalWidth) {
         if (originalWidth.length > 1) {
-          return null;
+          var variableWidths = startingStyle.match(/\[.*?[><=].*?].*?{\s*?marker\-width\:\s*?\d.*?;\s*?}/g).join('\n');
+          return {
+            ramp: variableWidths,
+            fixed: originalWidth[0].trim().replace('marker-width:', '').replace(';', '')
+          };
         } else {
           originalWidth = originalWidth[0].trim().replace('marker-width:', '').replace(';', '');
         }
@@ -52,6 +56,7 @@ AutoStyler.STYLE_TEMPLATE_LIGHT = {
          '  marker-line-width: 1;',
          '  marker-line-opacity: 0.8;',
          '  {{ramp}}',
+         '  {{wramp}}',
          '}'].join('\n'),
   line: ['{{layername}}',
           '  line-color: {{defaultColor}};',
@@ -82,6 +87,7 @@ AutoStyler.STYLE_TEMPLATE_DARK = {
         '  marker-line-width: 1;',
         '  marker-line-opacity: 0.5;',
         '  {{ramp}}',
+        '  {{wramp}}',
          '}'].join('\n'),
   line: ['{{layername}}',
           '  line-color: {{defaultColor}};',

--- a/src/widgets/auto-style/category.js
+++ b/src/widgets/auto-style/category.js
@@ -1,5 +1,4 @@
 var AutoStyler = require('./auto-styler');
-var _ = require('underscore');
 var CategoryAutoStyler = AutoStyler.extend({
   getStyle: function () {
     var style = this.layer.get('meta').cartocss;
@@ -12,7 +11,7 @@ var CategoryAutoStyler = AutoStyler.extend({
   _generateCategoryRamp: function (sym) {
     var ramp;
     var cats = this.dataviewModel.get('allCategoryNames');
-    ramp = 'marker-fill: ' + this.colors.getColorByCategory('OTHER') + ';';
+    ramp = sym + ': ' + this.colors.getColorByCategory('OTHER') + ';';
     ramp += cats.map(function (c, i) {
       var color = this.colors.getColorByCategory(c);
       return '[' + this.dataviewModel.get('column') + '=\'' + cats[i] + '\']{\n' + sym + ': ' + color + ';\n}';

--- a/src/widgets/auto-style/category.js
+++ b/src/widgets/auto-style/category.js
@@ -2,38 +2,20 @@ var AutoStyler = require('./auto-styler');
 var _ = require('underscore');
 var CategoryAutoStyler = AutoStyler.extend({
   getStyle: function () {
-    var preservedWidth = this.getPreservedWidth();
-    var style = '';
-    var defColor = this.colors.getColorByCategory('Other');
-    var stylesByGeometry = this.STYLE_TEMPLATE;
-    var geometryType = this.layer.getGeometryType();
-    if (geometryType) {
-      var ramp = this._generateCategoryRamp(geometryType);
-      style = stylesByGeometry[geometryType]
-        .replace('{{ramp}}', ramp)
-        .replace('{{layername}}', '#layer{');
-    } else {
-      for (var symbol in stylesByGeometry) {
-        style += stylesByGeometry[symbol]
-          .replace('{{layername}}', this._getLayerHeader(symbol))
-          .replace('{{ramp}}', this._generateCategoryRamp(symbol));
-      }
-    }
-    style = style.replace(/{{defaultColor}}/g, defColor);
-    if (!_.isEmpty(preservedWidth)) {
-      style = style.replace('{{markerWidth}}', preservedWidth);
-    } else {
-      style = style.replace('{{markerWidth}}', 7);
-    }
+    var style = this.layer.get('meta').cartocss;
+    ['marker-fill', 'polygon-fill', 'line-color'].forEach(function (item) {
+      style = style.replace(new RegExp('\\' + 's' + item + ':.*?;', 'g'), this._generateCategoryRamp(item));
+    }.bind(this));
     return style;
   },
 
   _generateCategoryRamp: function (sym) {
+    var ramp;
     var cats = this.dataviewModel.get('allCategoryNames');
-    var geomMap = { polygon: 'polygon-fill', marker: 'marker-fill', line: 'line-color' };
-    var ramp = cats.map(function (c, i) {
+    ramp = 'marker-fill: ' + this.colors.getColorByCategory('OTHER') + ';';
+    ramp += cats.map(function (c, i) {
       var color = this.colors.getColorByCategory(c);
-      return '[' + this.dataviewModel.get('column') + '=\'' + cats[i] + '\']{\n' + geomMap[sym] + ': ' + color + ';\n}';
+      return '[' + this.dataviewModel.get('column') + '=\'' + cats[i] + '\']{\n' + sym + ': ' + color + ';\n}';
     }.bind(this)).join('\n');
     return ramp;
   }

--- a/src/widgets/auto-style/category.js
+++ b/src/widgets/auto-style/category.js
@@ -1,7 +1,7 @@
 var AutoStyler = require('./auto-styler');
 var CategoryAutoStyler = AutoStyler.extend({
   getStyle: function () {
-    var style = this.layer.get('meta').cartocss;
+    var style = this.layer.get('initialStyle');
     ['marker-fill', 'polygon-fill', 'line-color'].forEach(function (item) {
       style = style.replace(new RegExp('\\' + 's' + item + ':.*?;', 'g'), this._generateCategoryRamp(item));
     }.bind(this));

--- a/src/widgets/auto-style/category.js
+++ b/src/widgets/auto-style/category.js
@@ -2,6 +2,7 @@ var AutoStyler = require('./auto-styler');
 var CategoryAutoStyler = AutoStyler.extend({
   getStyle: function () {
     var style = this.layer.get('initialStyle');
+    if (!style) return;
     ['marker-fill', 'polygon-fill', 'line-color'].forEach(function (item) {
       style = style.replace(new RegExp('\\' + 's' + item + ':.*?;', 'g'), this._generateCategoryRamp(item));
     }.bind(this));

--- a/src/widgets/auto-style/histogram.js
+++ b/src/widgets/auto-style/histogram.js
@@ -1,7 +1,7 @@
 var AutoStyler = require('./auto-styler');
 var HistogramAutoStyler = AutoStyler.extend({
   getStyle: function () {
-    var style = this.layer.get('meta').cartocss;
+    var style = this.layer.get('initialStyle');
     ['marker-fill', 'polygon-fill', 'line-color'].forEach(function (item) {
       style = style.replace(new RegExp('\\' + 's' + item + ':.*?;', 'g'), this.getColorLine(item));
     }.bind(this));

--- a/src/widgets/auto-style/histogram.js
+++ b/src/widgets/auto-style/histogram.js
@@ -2,6 +2,7 @@ var AutoStyler = require('./auto-styler');
 var HistogramAutoStyler = AutoStyler.extend({
   getStyle: function () {
     var style = this.layer.get('initialStyle');
+    if(!style) return;
     ['marker-fill', 'polygon-fill', 'line-color'].forEach(function (item) {
       style = style.replace(new RegExp('\\' + 's' + item + ':.*?;', 'g'), this.getColorLine(item));
     }.bind(this));

--- a/src/widgets/auto-style/histogram.js
+++ b/src/widgets/auto-style/histogram.js
@@ -2,7 +2,7 @@ var AutoStyler = require('./auto-styler');
 var HistogramAutoStyler = AutoStyler.extend({
   getStyle: function () {
     var style = this.layer.get('initialStyle');
-    if(!style) return;
+    if (!style) return;
     ['marker-fill', 'polygon-fill', 'line-color'].forEach(function (item) {
       style = style.replace(new RegExp('\\' + 's' + item + ':.*?;', 'g'), this.getColorLine(item));
     }.bind(this));

--- a/src/widgets/category/category-widget-model.js
+++ b/src/widgets/category/category-widget-model.js
@@ -73,7 +73,11 @@ module.exports = WidgetModel.extend({
   autoStyle: function () {
     var layer = this.dataviewModel.layer;
     if (!layer.get('initialStyle')) {
-      layer.set('initialStyle', layer.get('cartocss') || layer.get('meta').cartocss);
+      var initialStyle = layer.get('cartocss');
+      if (!initialStyle && layer.get('meta')) {
+        initialStyle = layer.get('meta').cartocss;
+      }
+      layer.set('initialStyle', initialStyle);
     }
     this.autoStyler.colors.updateData(this.dataviewModel.get('allCategoryNames'));
     var style = this.autoStyler.getStyle();

--- a/src/widgets/category/category-widget-model.js
+++ b/src/widgets/category/category-widget-model.js
@@ -71,9 +71,13 @@ module.exports = WidgetModel.extend({
   },
 
   autoStyle: function () {
+    var layer = this.dataviewModel.layer;
+    if (!layer.get('initialStyle')) {
+      layer.set('initialStyle', layer.get('cartocss') || layer.get('meta').cartocss);
+    }
     this.autoStyler.colors.updateData(this.dataviewModel.get('allCategoryNames'));
     var style = this.autoStyler.getStyle();
-    this.dataviewModel.layer.set('cartocss', style);
+    layer.set('cartocss', style);
     this.set('autoStyle', true);
   },
 

--- a/src/widgets/histogram/histogram-widget-model.js
+++ b/src/widgets/histogram/histogram-widget-model.js
@@ -35,7 +35,11 @@ module.exports = WidgetModel.extend({
   autoStyle: function () {
     var layer = this.dataviewModel.layer;
     if (!layer.get('initialStyle')) {
-      layer.set('initialStyle', layer.get('cartocss') || layer.get('meta').cartocss);
+      var initialStyle = layer.get('cartocss');
+      if (!initialStyle && layer.get('meta')) {
+        initialStyle = layer.get('meta').cartocss;
+      }
+      layer.set('initialStyle', initialStyle);
     }
     var style = this.autoStyler.getStyle();
     this.dataviewModel.layer.set('cartocss', style);

--- a/src/widgets/histogram/histogram-widget-model.js
+++ b/src/widgets/histogram/histogram-widget-model.js
@@ -33,6 +33,10 @@ module.exports = WidgetModel.extend({
   },
 
   autoStyle: function () {
+    var layer = this.dataviewModel.layer;
+    if (!layer.get('initialStyle')) {
+      layer.set('initialStyle', layer.get('cartocss') || layer.get('meta').cartocss);
+    }
     var style = this.autoStyler.getStyle();
     this.dataviewModel.layer.set('cartocss', style);
     this.set('autoStyle', true);


### PR DESCRIPTION
This gets rid of all the problems we've had related to cartocss changing dramatically when hitting autostyle. Now, instead of using predefined templates, we just modify some lines in the cartocss and pass it to the tiler as is.

@javisantana @makella 

![sickauto](https://cloud.githubusercontent.com/assets/3707222/16434433/0ed09e9a-3d90-11e6-98f3-dfcb338dbb0e.gif)
