### PR TITLE
createDashboard handles errors diferently

### DIFF
--- a/spec/api/create-dashboard.spec.js
+++ b/spec/api/create-dashboard.spec.js
@@ -69,14 +69,32 @@ describe('create-dashboard', function () {
 
       createDashboard(this.selectorId, this.vizJSON, {}, callback);
 
-      // visjson is loaded into the vis
+      // visjson is loaded into the vis and map instantiation succeeded
       this.visMock.trigger('load', this.visMock);
+      this.visMock.instantiateMap.calls.argsFor(0)[0].success();
 
       expect(callback).toHaveBeenCalled();
       var error = callback.calls.argsFor(0)[0];
       var dashboard = callback.calls.argsFor(0)[1];
 
       expect(error).toBe(null);
+      expect(dashboard instanceof APIDashboard).toBeTruthy();
+    });
+
+    it('should return an API dashboard object and error if there was an error', function () {
+      var callback = jasmine.createSpy('callback');
+
+      createDashboard(this.selectorId, this.vizJSON, {}, callback);
+
+      // visjson is loaded into the vis and map instantiation failed
+      this.visMock.trigger('load', this.visMock);
+      this.visMock.instantiateMap.calls.argsFor(0)[0].error();
+
+      expect(callback).toHaveBeenCalled();
+      var error = callback.calls.argsFor(0)[0];
+      var dashboard = callback.calls.argsFor(0)[1];
+
+      expect(error).not.toBe(null);
       expect(dashboard instanceof APIDashboard).toBeTruthy();
     });
 

--- a/src/api/create-dashboard.js
+++ b/src/api/create-dashboard.js
@@ -103,19 +103,24 @@ var createDashboard = function (selector, vizJSON, opts, callback) {
       vis.centerMapToOrigin();
     }
 
-    vis.done(function () {
-      callback && callback(null, {
-        dashboardView: dashboardView,
-        widgets: widgetsService,
-        vis: vis
-      });
+    vis.instantiateMap({
+      success: function () {
+        callback && callback(null, {
+          dashboardView: dashboardView,
+          widgets: widgetsService,
+          vis: vis
+        });
+      },
+      error: function () {
+        var error = new Error('Map instantiation failed');
+        console.log(error);
+        callback && callback(error, {
+          dashboardView: dashboardView,
+          widgets: widgetsService,
+          vis: vis
+        });
+      }
     });
-
-    vis.error(function (error) {
-      callback && callback(error);
-    });
-
-    vis.instantiateMap();
   });
 };
 
@@ -129,16 +134,14 @@ module.exports = function (selector, vizJSON, opts, callback) {
 
   function _load (vizJSON) {
     createDashboard(selector, vizJSON, opts, function (error, dashboard) {
-      if (error) {
-        throw new Error('Error creating dashboard: ' + error);
-      }
       var dash = new Dashboard(dashboard);
       if (opts.share_urls) {
         dash.onStateChanged(_.debounce(function (state, url) {
           window.history.replaceState('Object', 'Title', url);
         }, 500));
       }
-      callback && callback(null, dash);
+
+      callback && callback(error, dash);
     });
   }
 


### PR DESCRIPTION
`createDashboard` was throwing an error, which was preventing the UI from being rendered.

Changes:
  - createDashboard doesn't throw error and forwards error to the callback instead.
  - Usage of `vis.instantiateMap` now gets an object with `success` and `error` callbacks instead of using `vis.done` and `vis.error` (which were not working). See: https://github.com/CartoDB/cartodb.js/pull/1334

@xavijam sounds good?