### PR TITLE
Remove url state fetch

### DIFF
--- a/src/api/create-dashboard.js
+++ b/src/api/create-dashboard.js
@@ -47,11 +47,12 @@ var createDashboard = function (selector, vizJSON, opts, callback) {
     widgets: widgets,
     model: model
   });
-  var stateFromURL = opts.state || URLHelper.getStateFromCurrentURL();
-  if (!_.isEmpty(stateFromURL.map)) {
-    vizJSON.center = stateFromURL.map.center;
+
+  var state = opts.state;
+  if (!_.isEmpty(state.map)) {
+    vizJSON.center = state.map.center;
     vizJSON.bounds = null;
-    vizJSON.zoom = stateFromURL.map.zoom;
+    vizJSON.zoom = state.map.zoom;
   }
 
   var vis = cdb.createVis(dashboardView.$('#map'), vizJSON, _.extend(opts, {
@@ -59,11 +60,11 @@ var createDashboard = function (selector, vizJSON, opts, callback) {
   }));
 
   vis.once('load', function (vis) {
-    if (!_.isEmpty(stateFromURL.map)) {
-      vis.map.setView(stateFromURL.map.center, stateFromURL.map.zoom);
+    if (!_.isEmpty(state.map)) {
+      vis.map.setView(state.map.center, state.map.zoom);
     }
 
-    var widgetsState = stateFromURL.widgets || {};
+    var widgetsState = state.widgets || {};
 
     // Create widgets
     var widgetsService = new WidgetsService(widgets, vis.dataviews);
@@ -78,7 +79,7 @@ var createDashboard = function (selector, vizJSON, opts, callback) {
       // Flatten the data structure given in vizJSON, the widgetsService will use whatever it needs and ignore the rest
       var attrs = _.extend({}, d, d.options);
       var newWidgetModel = widgetModelsMap[d.type];
-      var state = widgetsState[d.id];
+      var widgetState = widgetsState[d.id];
 
       if (_.isFunction(newWidgetModel)) {
         // Find the Layer that the Widget should be created for.
@@ -91,7 +92,7 @@ var createDashboard = function (selector, vizJSON, opts, callback) {
           layer = vis.map.layers.at(d.layerIndex);
         }
 
-        newWidgetModel(attrs, layer, state);
+        newWidgetModel(attrs, layer, widgetState);
       } else {
         cdb.log.error('No widget found for type ' + d.type);
       }

--- a/src/api/create-dashboard.js
+++ b/src/api/create-dashboard.js
@@ -4,7 +4,6 @@ var Dashboard = require('./dashboard');
 var DashboardView = require('../dashboard-view');
 var WidgetsCollection = require('../widgets/widgets-collection');
 var WidgetsService = require('../widgets-service');
-var URLHelper = require('./url-helper');
 
 /**
  * Translates a vizJSON v3 datastructure into a working dashboard which will be rendered in given selector.

--- a/src/api/create-dashboard.js
+++ b/src/api/create-dashboard.js
@@ -47,7 +47,7 @@ var createDashboard = function (selector, vizJSON, opts, callback) {
     model: model
   });
 
-  var state = opts.state;
+  var state = opts.state || {};
   if (!_.isEmpty(state.map)) {
     vizJSON.center = state.map.center;
     vizJSON.bounds = null;


### PR DESCRIPTION
Dashboard now relies only on whatever state is provided through options.

The decision to take the state from the URL or elsewhere is now taken by the Cartodb UI. The dashboard does retain the capacity of generating urls though (`getDashboardURL`) and make them copiable and sharable :).

This can be merged when https://github.com/CartoDB/cartodb/pull/8507 is merged.

Please, @fdansv have a look!

cc/ @javisantana 