### PR TITLE
Rounds default numeric values

### DIFF
--- a/src/widgets/histogram/histogram-widget-model.js
+++ b/src/widgets/histogram/histogram-widget-model.js
@@ -10,13 +10,7 @@ module.exports = WidgetModel.extend({
   defaultState: _.extend(
     {
       autoStyle: false,
-      normalized: false,
-      min: function () {
-        return this.dataviewModel.get('start');
-      },
-      max: function () {
-        return this.dataviewModel.get('end');
-      }
+      normalized: false
     },
     WidgetModel.prototype.defaultState
   ),
@@ -53,6 +47,27 @@ module.exports = WidgetModel.extend({
   cancelAutoStyle: function () {
     this.dataviewModel.layer.restoreCartoCSS();
     this.set('autoStyle', false);
+  },
+
+  getState: function () {
+    var state = WidgetModel.prototype.getState.call(this);
+    var start = this.dataviewModel.get('start');
+    var end = this.dataviewModel.get('end');
+    var min = this.get('min');
+    var max = this.get('max');
+    var checkRoughEqual = function (a, b) {
+      if (_.isNumber(a) && _.isNumber(b) && Math.abs(start - min) > Number.EPSILON) {
+        return true;
+      }
+      return false;
+    };
+    if (checkRoughEqual(start, min)) {
+      state.min = min;
+    }
+    if (checkRoughEqual(end, max)) {
+      state.max = max;
+    }
+    return state;
   }
 
 });

--- a/src/widgets/histogram/histogram-widget-model.js
+++ b/src/widgets/histogram/histogram-widget-model.js
@@ -56,7 +56,7 @@ module.exports = WidgetModel.extend({
     var min = this.get('min');
     var max = this.get('max');
     var checkRoughEqual = function (a, b) {
-      if (_.isNumber(a) && _.isNumber(b) && Math.abs(start - min) > Number.EPSILON) {
+      if (_.isNumber(a) && _.isNumber(b) && Math.abs(a - b) > Math.abs(start - end) * 0.01) {
         return true;
       }
       return false;

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -53,11 +53,17 @@ module.exports = cdb.core.Model.extend({
     var state = {};
     for (var key in this.defaultState) {
       var attribute = this.get(key);
+      if (_.isNumber(attribute)) {
+        attribute = Math.round(attribute);
+      }
       var defaultValue = this.defaultState[key];
       if (typeof defaultValue === 'function') {
         defaultValue = defaultValue.call(this);
       }
-      if (typeof attribute !== 'undefined' && !_.isEqual(attribute, defaultValue)) {
+      if (_.isNumber(defaultValue)) {
+        defaultValue = Math.round(defaultValue);
+      }
+      if (typeof defaultValue !== 'undefined' && typeof attribute !== 'undefined' && !_.isEqual(attribute, defaultValue)) {
         state[key] = attribute;
       }
     }

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -53,16 +53,11 @@ module.exports = cdb.core.Model.extend({
     var state = {};
     for (var key in this.defaultState) {
       var attribute = this.get(key);
-      if (_.isNumber(attribute)) {
-        attribute = Math.round(attribute);
-      }
       var defaultValue = this.defaultState[key];
       if (typeof defaultValue === 'function') {
         defaultValue = defaultValue.call(this);
       }
-      if (_.isNumber(defaultValue)) {
-        defaultValue = Math.round(defaultValue);
-      }
+      if (_.isNumber(attribute) && _.isNumber(defaultValue) && Math.abs(attribute - defaultValue) / attribute < 0.10) continue;
       if (typeof defaultValue !== 'undefined' && typeof attribute !== 'undefined' && !_.isEqual(attribute, defaultValue)) {
         state[key] = attribute;
       }

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -54,10 +54,6 @@ module.exports = cdb.core.Model.extend({
     for (var key in this.defaultState) {
       var attribute = this.get(key);
       var defaultValue = this.defaultState[key];
-      if (typeof defaultValue === 'function') {
-        defaultValue = defaultValue.call(this);
-      }
-      if (_.isNumber(attribute) && _.isNumber(defaultValue) && Math.abs(attribute - defaultValue) / attribute < 0.10) continue;
       if (typeof defaultValue !== 'undefined' && typeof attribute !== 'undefined' && !_.isEqual(attribute, defaultValue)) {
         state[key] = attribute;
       }


### PR DESCRIPTION
Sometimes the values returned by the tiler differ from the ones in the dataview by decimal positions. This isn't really solving the problem, but it is a hotfix to avoid setting wrong values in the state.

Fixes https://github.com/CartoDB/cartodb/issues/8460

@javisantana 