### PR TITLE
Adding urls without params + target blank for user info

### DIFF
--- a/src/dashboard-menu-view.js
+++ b/src/dashboard-menu-view.js
@@ -22,6 +22,7 @@ var DashboardMenuView = cdb.core.View.extend({
         updatedAt: moment(this.model.get('updatedAt')).fromNow(),
         userName: this.model.get('userName'),
         url: window.location.href,
+        urlWithoutParams: window.location.protocol + '//' + window.location.host + window.location.pathname,
         inIframe: (window.location !== window.parent.location),
         shortTitle: shortTitle,
         userAvatarURL: this.model.get('userAvatarURL'),

--- a/src/dashboard-menu-view.tpl
+++ b/src/dashboard-menu-view.tpl
@@ -17,12 +17,12 @@
 
       <ul class="CDB-Dashboard-menuActions">
         <li class="CDB-Dashboard-menuActionsItem">
-          <a href="https://twitter.com/share?url=<%- url %>&text=<%- shortTitle %>" class="u-hintTextColor">
+          <a href="https://twitter.com/share?url=<%- urlWithoutParams %>&text=<%- shortTitle %>" class="u-hintTextColor">
             <i class="CDB-IconFont CDB-IconFont-twitter CDB-Size-large"></i>
           </a>
         </li>
         <li class="CDB-Dashboard-menuActionsItem">
-          <a href="http://www.facebook.com/sharer.php?u=<%- url %>&text=<%- shortTitle %>" class="u-hintTextColor">
+          <a href="http://www.facebook.com/sharer.php?u=<%- urlWithoutParams %>&text=<%- shortTitle %>" class="u-hintTextColor">
             <i class="CDB-IconFont CDB-IconFont-facebook CDB-Size-medium"></i>
           </a>
         </li>
@@ -65,7 +65,7 @@
           <div class="CDB-Dashboard-menuMedia CDB-Dashboard-menuAvatar">
             <img src="<%- userAvatarURL %>" alt="avatar" class="inline-block"/>
           </div>
-          <p class="CDB-Text CDB-Size-medium CDB-Dashboard-menuFooterTxt">Map by <a href="<%- userProfileURL %>"><%- userName %></a></p>
+          <p class="CDB-Text CDB-Size-medium CDB-Dashboard-menuFooterTxt">Map by <a href="<%- userProfileURL %>" target="_blank"><%- userName %></a></p>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Twitter can't share an url super long (probably due to the state url feature), so let's share in Facebook and Twitter urls without params.

CR: @javisantana 
cc @piensaenpixel 