### PR TITLE
Fixes with Normalize

### DIFF
--- a/src/widgets/dropdown/widget-dropdown-view.js
+++ b/src/widgets/dropdown/widget-dropdown-view.js
@@ -46,7 +46,7 @@ module.exports = cdb.core.View.extend({
     this.add_related_model(this.model);
 
     this.model.bind('change:widget_dropdown_open', this._onChangeOpen, this);
-    this.model.bind('change:pinned change:collapsed change:normalized', this.render, this);
+    this.model.bind('change:pinned change:collapsed', this.render, this);
 
     this._$container.delegate(this._target, 'click',
       _.bind(this._toggleClick, this)

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -184,6 +184,7 @@ module.exports = cdb.core.View.extend({
 
   _onChangeNormalized: function () {
     // do not show shadow bars if they are not enabled
+    this.model.set('show_shadow_bars', !this.model.get('normalized'))
     this._generateShadowBars();
     this.updateYScale();
     this.refresh();

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -184,7 +184,7 @@ module.exports = cdb.core.View.extend({
 
   _onChangeNormalized: function () {
     // do not show shadow bars if they are not enabled
-    this.model.set('show_shadow_bars', !this.model.get('normalized'))
+    this.model.set('show_shadow_bars', !this.model.get('normalized'));
     this._generateShadowBars();
     this.updateYScale();
     this.refresh();

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -47,6 +47,7 @@ module.exports = cdb.core.View.extend({
 
     this.model.bind('change:normalized', function () {
       var normalized = this.model.get('normalized');
+      this._resetWidget()
       this.histogramChartView.setNormalized(normalized);
       this.miniHistogramChartView.setNormalized(normalized);
     }, this);

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -45,10 +45,6 @@ module.exports = cdb.core.View.extend({
       }
     });
 
-    this.model.bind('change:normalized', function () {
-      var normalized = this.model.get('normalized');
-    }, this);
-
     this.addView(dropdown);
 
     this._renderMiniChart();
@@ -67,7 +63,12 @@ module.exports = cdb.core.View.extend({
 
   _initBinds: function () {
     this._originalData.once('change:data', this._onFirstLoad, this);
-    this.model.bind('change:collapsed change:pinned change:normalized', this.render, this);
+    this.model.bind('change:collapsed change:pinned', this.render, this);
+    this.model.bind('change:normalized', function(){
+      normalized = this.model.get('normalized');
+      this.histogramChartView.setNormalized(normalized);
+      this.miniHistogramChartView.setNormalized(normalized);
+    }, this);
   },
 
   _onFirstLoad: function () {
@@ -434,14 +435,17 @@ module.exports = cdb.core.View.extend({
   },
 
   _resetWidget: function () {
-    this.unsettingRange = true;
+    this.filter.unsetRange();
+    this._dataviewModel.disableFilter();
+    this.histogramChartView.unsetBounds();
+    this.miniHistogramChartView.hide();
     this.model.set({
       zoomed: false,
       zoom_enabled: false,
       filter_enabled: false,
       lo_index: null,
-      hi_index: null,
+      hi_index: null
     });
-    this._dataviewModel.disableFilter();
+    this._updateStats();
   }
 });

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -64,8 +64,8 @@ module.exports = cdb.core.View.extend({
   _initBinds: function () {
     this._originalData.once('change:data', this._onFirstLoad, this);
     this.model.bind('change:collapsed change:pinned', this.render, this);
-    this.model.bind('change:normalized', function(){
-      normalized = this.model.get('normalized');
+    this.model.bind('change:normalized', function () {
+      var normalized = this.model.get('normalized');
       this.histogramChartView.setNormalized(normalized);
       this.miniHistogramChartView.setNormalized(normalized);
     }, this);

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -47,9 +47,6 @@ module.exports = cdb.core.View.extend({
 
     this.model.bind('change:normalized', function () {
       var normalized = this.model.get('normalized');
-      this._resetWidget()
-      this.histogramChartView.setNormalized(normalized);
-      this.miniHistogramChartView.setNormalized(normalized);
     }, this);
 
     this.addView(dropdown);
@@ -437,7 +434,6 @@ module.exports = cdb.core.View.extend({
   },
 
   _resetWidget: function () {
-    this.lockedByUser = true;
     this.unsettingRange = true;
     this.model.set({
       zoomed: false,
@@ -445,12 +441,7 @@ module.exports = cdb.core.View.extend({
       filter_enabled: false,
       lo_index: null,
       hi_index: null,
-      min: this._dataviewModel.start,
-      max: this._dataviewModel.end
     });
     this._dataviewModel.disableFilter();
-    this.filter.unsetRange();
-    this.histogramChartView.unsetBounds();
-    this.miniHistogramChartView.hide();
   }
 });


### PR DESCRIPTION
- Close #383 
- Remove unnecessary bind to normalized on initialize function.
- avoid to re-render the widget when activating/deactivating normalisation (was a pending enhancement)
- Showing stats after activating/deactivating normalization
- Refactors make _resetWidget making use of _updateStats