### PR TITLE
Disable widget state

### DIFF
--- a/spec/widgets/time-series/torque-content-view.spec.js
+++ b/spec/widgets/time-series/torque-content-view.spec.js
@@ -20,7 +20,9 @@ describe('widgets/time-series/torque-content-view', function () {
     this.dataviewModel.sync = function (method, model, options) {
       this.options = options;
     }.bind(this);
-    this.torqueLayerModel = new cdb.geo.TorqueLayer();
+    this.torqueLayerModel = new cdb.geo.TorqueLayer({}, {
+      vis: vis
+    });
     var widgetModel = new WidgetModel({}, {
       dataviewModel: this.dataviewModel
     });

--- a/spec/widgets/time-series/torque-time-slider-view.spec.js
+++ b/spec/widgets/time-series/torque-time-slider-view.spec.js
@@ -20,6 +20,8 @@ describe('widgets/time-series/torque-time-slider-view', function () {
       steps: 256,
       start: 0,
       end: 1000
+    }, {
+      vis: vis
     });
 
     this.histogramChartMargins = {

--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -37,11 +37,11 @@ Dashboard.prototype = {
     var mapState = this.getMapState(); // TODO
     if (!_.isEmpty(mapState)) state.map = mapState;
     /*
-    * Disabled widget states until issues are fixed.
+    * TODO: Disabled widget states until issues are fixed.
     * See https://github.com/CartoDB/deep-insights.js/issues/416
-    * var widgetsState = this._dashboard.widgets._widgetsCollection.getStates();
-    * if (!_.isEmpty(widgetsState)) state.widgets = widgetsState;
     */
+    // var widgetsState = this._dashboard.widgets._widgetsCollection.getStates();
+    // if (!_.isEmpty(widgetsState)) state.widgets = widgetsState;
     return state;
   },
 

--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -33,11 +33,15 @@ Dashboard.prototype = {
   },
 
   getState: function () {
-    var widgetsState = this._dashboard.widgets._widgetsCollection.getStates();
-    var mapState = this.getMapState(); // TODO
     var state = {};
+    var mapState = this.getMapState(); // TODO
     if (!_.isEmpty(mapState)) state.map = mapState;
-    if (!_.isEmpty(widgetsState)) state.widgets = widgetsState;
+    /*
+    * Disabled widget states until issues are fixed.
+    * See https://github.com/CartoDB/deep-insights.js/issues/416
+    * var widgetsState = this._dashboard.widgets._widgetsCollection.getStates();
+    * if (!_.isEmpty(widgetsState)) state.widgets = widgetsState;
+    */
     return state;
   },
 

--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -37,9 +37,9 @@ Dashboard.prototype = {
     var mapState = this.getMapState(); // TODO
     if (!_.isEmpty(mapState)) state.map = mapState;
     /*
-    * TODO: Disabled widget states until issues are fixed.
-    * See https://github.com/CartoDB/deep-insights.js/issues/416
-    */
+     * TODO: Disabled widget states until issues are fixed.
+     * See https://github.com/CartoDB/deep-insights.js/issues/416
+     */
     // var widgetsState = this._dashboard.widgets._widgetsCollection.getStates();
     // if (!_.isEmpty(widgetsState)) state.widgets = widgetsState;
     return state;
@@ -69,9 +69,14 @@ Dashboard.prototype = {
   },
 
   onStateChanged: function (callback) {
-    this._dashboard.widgets._widgetsCollection.bind('change', function () {
-      callback(this.getState(), this.getDashboardURL());
-    }, this);
+    /*
+     * TODO: Disabled widget states until issues are fixed.
+     * See https://github.com/CartoDB/deep-insights.js/issues/416
+     */
+    // this._dashboard.widgets._widgetsCollection.bind('change', function () {
+    //   callback(this.getState(), this.getDashboardURL());
+    // }, this);
+
     this._dashboard.vis.map.bind('change', function () {
       callback(this.getState(), this.getDashboardURL());
     }, this);


### PR DESCRIPTION
This disables widget state until [the issues with it](https://github.com/CartoDB/deep-insights.js/issues/416) are fixed. Until then, only map related state is shared (i.e, viewport).

Please CR @xavijam 