### PR TITLE
Using proper dependencies for browserify-resolutions

### DIFF
--- a/grunt-tasks/browserify.js
+++ b/grunt-tasks/browserify.js
@@ -24,9 +24,7 @@ module.exports = {
         standalone: 'cartodb'
       },
       plugin: [
-        ['browserify-resolutions', '*']
-        // To be more specific we could use the following
-        // ['browserify-resolutions', ['backbone']]
+        ['browserify-resolutions', ['backbone', 'cartodb.js', 'd3', 'jquery', 'moment', 'perfect-scrollbar', 'urijs', 'underscore']]
       ]
     }
   },
@@ -45,8 +43,6 @@ module.exports = {
       external: vendorDependencies,
       plugin: [
         ['browserify-resolutions', vendorDependencies]
-        // To be more specific we could use the following
-        // ['browserify-resolutions', ['backbone']]
       ]
     }
   }


### PR DESCRIPTION
It fixes the problem we have right now with the bundle generation.

cc @nobuti 
