### PR TITLE
Complete cleaning for repetitives symbolizers fix #457

### DIFF
--- a/spec/widgets/auto-style/category.spec.js
+++ b/spec/widgets/auto-style/category.spec.js
@@ -32,22 +32,22 @@ describe('src/widgets/auto-style/category', function () {
   describe('.getStyle', function () {
     it('should generate the right styles when layer has polygons', function () {
       this.dataview.layer.set('initialStyle', '#layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1;  polygon-fill: #e49115;  polygon-fill-opacity: 0.9; }');
-      expect(this.categoryAutoStyler.getStyle()).toBe('#layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1; polygon-fill: ramp([something], (#7F3C8D, #11A579, #3969AC, #F2B701, #E73F74), (\'soccer\', \'basketball\', \'baseball\', \'handball\', \'hockey\'));  polygon-fill-opacity: 0.9; }');
+      expect(this.categoryAutoStyler.getStyle()).toBe('#layer { polygon-fill: ramp([something], (#7F3C8D, #11A579, #3969AC, #F2B701, #E73F74), (\'soccer\', \'basketball\', \'baseball\', \'handball\', \'hockey\'));  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1;   polygon-fill-opacity: 0.9; }');
     });
 
     it('should generate the right styles when layer has points', function () {
       this.layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
-      expect(this.categoryAutoStyler.getStyle()).toBe('#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077; marker-fill: ramp([something], (#7F3C8D, #11A579, #3969AC, #F2B701, #E73F74), (\'soccer\', \'basketball\', \'baseball\', \'handball\', \'hockey\'));  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
+      expect(this.categoryAutoStyler.getStyle()).toBe('#layer { marker-fill: ramp([something], (#7F3C8D, #11A579, #3969AC, #F2B701, #E73F74), (\'soccer\', \'basketball\', \'baseball\', \'handball\', \'hockey\'));  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;   marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
     });
 
     it('should generate the right styles when layer has lines', function () {
       this.dataview.layer.set('initialStyle', '#layer {  line-width: 0.5;  line-color: #fcfafa;  line-opacity: 1; }');
-      expect(this.categoryAutoStyler.getStyle()).toBe('#layer {  line-width: 0.5; line-color: ramp([something], (#7F3C8D, #11A579, #3969AC, #F2B701, #E73F74), (\'soccer\', \'basketball\', \'baseball\', \'handball\', \'hockey\'));  line-opacity: 1; }');
+      expect(this.categoryAutoStyler.getStyle()).toBe("#layer { line-color: ramp([something], (#7F3C8D, #11A579, #3969AC, #F2B701, #E73F74), ('soccer', 'basketball', 'baseball', 'handball', 'hockey'));  line-width: 0.5;   line-opacity: 1; }");
     });
 
     it('should generate unique attr style when layer has multiple attrs', function () {
       this.dataview.layer.set('initialStyle', '#layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1;  polygon-fill: #e49115;  polygon-fill-opacity: 0.9; [random > 0.5] { polygon-fill: #adadad; } }');
-      expect(this.categoryAutoStyler.getStyle()).toBe('#layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1; polygon-fill: ramp([something], (#7F3C8D, #11A579, #3969AC, #F2B701, #E73F74), (\'soccer\', \'basketball\', \'baseball\', \'handball\', \'hockey\'));  polygon-fill-opacity: 0.9; }');
+      expect(this.categoryAutoStyler.getStyle()).toBe("#layer { polygon-fill: ramp([something], (#7F3C8D, #11A579, #3969AC, #F2B701, #E73F74), ('soccer', 'basketball', 'baseball', 'handball', 'hockey'));  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1;   polygon-fill-opacity: 0.9; }");
     });
 
     it('should escape single quotes correctly', function () {
@@ -56,7 +56,7 @@ describe('src/widgets/auto-style/category', function () {
       this.dataview.set('data', data);
       this.layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
       this.updateColorsByData();
-      expect(this.categoryAutoStyler.getStyle()).toBe('#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077; marker-fill: ramp([something], (#7F3C8D, #11A579, #3969AC, #F2B701, #E73F74, #A5AA99), (\'soccer\', \'basketball\', \'baseball\', \'handball\', \'hockey\', \'Oh\\\'Yeah\'));  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
+      expect(this.categoryAutoStyler.getStyle()).toBe("#layer { marker-fill: ramp([something], (#7F3C8D, #11A579, #3969AC, #F2B701, #E73F74, #A5AA99), ('soccer', 'basketball', 'baseball', 'handball', 'hockey', 'Oh\\'Yeah'));  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;   marker-fill-opacity: 0.9;  marker-allow-overlap: true;}");
     });
 
     it('should generate proper CartoCSS when Others is included', function () {
@@ -65,7 +65,7 @@ describe('src/widgets/auto-style/category', function () {
       this.dataview.set('data', data);
       this.layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
       this.updateColorsByData();
-      expect(this.categoryAutoStyler.getStyle()).toBe('#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077; marker-fill: ramp([something], (#7F3C8D, #11A579, #3969AC, #F2B701, #E73F74, #A5AA99), (\'soccer\', \'basketball\', \'baseball\', \'handball\', \'hockey\'));  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
+      expect(this.categoryAutoStyler.getStyle()).toBe("#layer { marker-fill: ramp([something], (#7F3C8D, #11A579, #3969AC, #F2B701, #E73F74, #A5AA99), ('soccer', 'basketball', 'baseball', 'handball', 'hockey'));  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;   marker-fill-opacity: 0.9;  marker-allow-overlap: true;}");
     });
   });
 });

--- a/spec/widgets/auto-style/category.spec.js
+++ b/spec/widgets/auto-style/category.spec.js
@@ -45,9 +45,14 @@ describe('src/widgets/auto-style/category', function () {
       expect(this.categoryAutoStyler.getStyle()).toBe('#layer {  line-width: 0.5; line-color: ramp([something], (#7F3C8D, #11A579, #3969AC, #F2B701, #E73F74), (\'soccer\', \'basketball\', \'baseball\', \'handball\', \'hockey\'));  line-opacity: 1; }');
     });
 
+    it('should generate unique attr style when layer has multiple attrs', function () {
+      this.dataview.layer.set('initialStyle', '#layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1;  polygon-fill: #e49115;  polygon-fill-opacity: 0.9; [random > 0.5] { polygon-fill: #adadad; } }');
+      expect(this.categoryAutoStyler.getStyle()).toBe('#layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1; polygon-fill: ramp([something], (#7F3C8D, #11A579, #3969AC, #F2B701, #E73F74), (\'soccer\', \'basketball\', \'baseball\', \'handball\', \'hockey\'));  polygon-fill-opacity: 0.9; }');
+    });
+
     it('should escape single quotes correctly', function () {
       var data = this.dataview.get('data');
-      data.push({ name: "Oh'Yeah" }); // eslint-disable-line 
+      data.push({ name: "Oh'Yeah" }); // eslint-disable-line
       this.dataview.set('data', data);
       this.layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
       this.updateColorsByData();

--- a/spec/widgets/auto-style/style-utils.spec.js
+++ b/spec/widgets/auto-style/style-utils.spec.js
@@ -1,0 +1,35 @@
+var StyleUtils = require('../../../src/widgets/auto-style/style-utils.js');
+
+describe('src/widgets/auto-style/style-utils', function () {
+  describe('.changeStyle', function () {
+    it('should change style attribute', function () {
+      var cartocss = '#layer {marker-line-color: white; marker-fill: #adadad;}';
+      var attr = 'marker-fill';
+      var newStyle = ' marker-fill: blue;';
+
+      var expected = '#layer {marker-line-color: white; marker-fill: blue;}';
+
+      expect(StyleUtils.changeStyle(cartocss, attr, newStyle)).toBe(expected);
+    });
+
+    it('should change style and remove duplicated', function () {
+      var cartocss = '#layer {marker-line-color: white; marker-fill: #adadad; marker-fill: #fafafa;}';
+      var attr = 'marker-fill';
+      var newStyle = ' marker-fill: blue;';
+
+      var expected = '#layer {marker-line-color: white; marker-fill: blue;}';
+
+      expect(StyleUtils.changeStyle(cartocss, attr, newStyle)).toBe(expected);
+    });
+
+    it('should change style, remove duplicated and remove empty braces', function () {
+      var cartocss = '#layer {marker-line-color: white; marker-fill: #adadad; [me>gasol] { marker-fill: #fafafa; }}';
+      var attr = 'marker-fill';
+      var newStyle = ' marker-fill: blue;';
+
+      var expected = '#layer {marker-line-color: white; marker-fill: blue;}';
+
+      expect(StyleUtils.changeStyle(cartocss, attr, newStyle)).toBe(expected);
+    });
+  });
+});

--- a/spec/widgets/auto-style/style-utils.spec.js
+++ b/spec/widgets/auto-style/style-utils.spec.js
@@ -3,31 +3,41 @@ var StyleUtils = require('../../../src/widgets/auto-style/style-utils.js');
 describe('src/widgets/auto-style/style-utils', function () {
   describe('.changeStyle', function () {
     it('should change style attribute', function () {
-      var cartocss = '#layer {marker-line-color: white; marker-fill: #adadad;}';
+      var cartocss = '#layer { marker-line-color: white; marker-fill: #adadad;}';
       var attr = 'marker-fill';
-      var newStyle = ' marker-fill: blue;';
+      var newStyle = 'marker-fill: blue;';
 
-      var expected = '#layer {marker-line-color: white; marker-fill: blue;}';
+      var expected = '#layer { marker-fill: blue; marker-line-color: white;}';
 
       expect(StyleUtils.changeStyle(cartocss, attr, newStyle)).toBe(expected);
     });
 
     it('should change style and remove duplicated', function () {
-      var cartocss = '#layer {marker-line-color: white; marker-fill: #adadad; marker-fill: #fafafa;}';
+      var cartocss = '#layer { marker-line-color: white; marker-fill: #adadad; marker-fill: #fafafa;}';
       var attr = 'marker-fill';
-      var newStyle = ' marker-fill: blue;';
+      var newStyle = 'marker-fill: blue;';
 
-      var expected = '#layer {marker-line-color: white; marker-fill: blue;}';
+      var expected = '#layer { marker-fill: blue; marker-line-color: white;}';
 
       expect(StyleUtils.changeStyle(cartocss, attr, newStyle)).toBe(expected);
     });
 
     it('should change style, remove duplicated and remove empty braces', function () {
-      var cartocss = '#layer {marker-line-color: white; marker-fill: #adadad; [me>gasol] { marker-fill: #fafafa; }}';
+      var cartocss = '#layer { marker-line-color: white; marker-fill: #adadad; [me>gasol] { marker-fill: #fafafa; }}';
       var attr = 'marker-fill';
-      var newStyle = ' marker-fill: blue;';
+      var newStyle = 'marker-fill: blue;';
 
-      var expected = '#layer {marker-line-color: white; marker-fill: blue;}';
+      var expected = '#layer { marker-fill: blue; marker-line-color: white;}';
+
+      expect(StyleUtils.changeStyle(cartocss, attr, newStyle)).toBe(expected);
+    });
+
+    it('should change style, remove duplicated and don\'t remove braces', function () {
+      var cartocss = '#layer { marker-line-color: white; marker-fill: #adadad; [me>gasol] { marker-fill: #fafafa; marker-line-color: green; }}';
+      var attr = 'marker-fill';
+      var newStyle = 'marker-fill: blue;';
+
+      var expected = '#layer { marker-fill: blue; marker-line-color: white; [me>gasol] { marker-line-color: green; }}';
 
       expect(StyleUtils.changeStyle(cartocss, attr, newStyle)).toBe(expected);
     });

--- a/src/widgets/auto-style/category.js
+++ b/src/widgets/auto-style/category.js
@@ -1,25 +1,6 @@
 var _ = require('underscore');
 var AutoStyler = require('./auto-styler');
-
-function getAttrRegex (attr, multi) {
-  return new RegExp('\\' + 's' + attr + ':.*?(;|\n)', multi ? 'g' : '');
-}
-
-function removeEmptyLayer (cartocss) {
-  return cartocss.replace(/[^;}{]*{((\s|\n)*?)}/g, '');
-}
-
-function setFlagInCartocss (cartocss, attr, flag) {
-  return cartocss.replace(getAttrRegex(attr, false), flag);
-}
-
-function removeAttr (cartocss, attr) {
-  return cartocss.replace(getAttrRegex(attr, true), '');
-}
-
-function insertCartoCSSAttribute (cartocss, attrib, flag) {
-  return cartocss.replace(flag, attrib);
-}
+var StyleUtils = require('./style-utils');
 
 module.exports = AutoStyler.extend({
   getStyle: function () {
@@ -27,20 +8,7 @@ module.exports = AutoStyler.extend({
     if (!style) return;
 
     ['marker-fill', 'polygon-fill', 'line-color'].forEach(function (item) {
-      var flag = '##' + item + '##;';
-
-      style = insertCartoCSSAttribute(
-                removeEmptyLayer(
-                  removeAttr(
-                    setFlagInCartocss(style, item, flag),
-                    item
-                  )
-                ),
-
-                this._generateCategoryRamp(item),
-                flag
-              );
-      // style = style.replace( new RegExp( '\\' + 's' + item + ':.*?(;|\n)', 'g' ), this._generateCategoryRamp( item ) );
+      style = StyleUtils.changeStyle(style, item, this._generateCategoryRamp(item));
     }.bind(this));
 
     return style;

--- a/src/widgets/auto-style/category.js
+++ b/src/widgets/auto-style/category.js
@@ -1,33 +1,33 @@
 var _ = require('underscore');
-var AutoStyler = require( './auto-styler' );
+var AutoStyler = require('./auto-styler');
 
-function getAttrRegex(attr, multi) {
+function getAttrRegex (attr, multi) {
   return new RegExp('\\' + 's' + attr + ':.*?(;|\n)', multi ? 'g' : '');
 }
 
-function removeEmptyLayer(cartocss) {
-  return cartocss.replace(/.*{((\s|\n)*?)}/g, '');
+function removeEmptyLayer (cartocss) {
+  return cartocss.replace(/[^;}{]*{((\s|\n)*?)}/g, '');
 }
 
-function setFlagInCartocss(cartocss, attr, flag) {
+function setFlagInCartocss (cartocss, attr, flag) {
   return cartocss.replace(getAttrRegex(attr, false), flag);
 }
 
-function removeAttr( cartocss, attr ) {
+function removeAttr (cartocss, attr) {
   return cartocss.replace(getAttrRegex(attr, true), '');
 }
 
-function insertCartoCSSAttribute(cartocss, attrib, flag) {
+function insertCartoCSSAttribute (cartocss, attrib, flag) {
   return cartocss.replace(flag, attrib);
 }
 
-module.exports = AutoStyler.extend( {
-  getStyle: function() {
-    var style = this.layer.get( 'initialStyle' );
-    if ( !style ) return;
+module.exports = AutoStyler.extend({
+  getStyle: function () {
+    var style = this.layer.get('initialStyle');
+    if (!style) return;
 
-    [ 'marker-fill', 'polygon-fill', 'line-color' ].forEach( function( item ) {
-      var flag = '##' + item + '##';
+    ['marker-fill', 'polygon-fill', 'line-color'].forEach(function (item) {
+      var flag = '##' + item + '##;';
 
       style = insertCartoCSSAttribute(
                 removeEmptyLayer(
@@ -37,11 +37,11 @@ module.exports = AutoStyler.extend( {
                   )
                 ),
 
-                this._generateCategoryRamp( item ),
+                this._generateCategoryRamp(item),
                 flag
               );
       // style = style.replace( new RegExp( '\\' + 's' + item + ':.*?(;|\n)', 'g' ), this._generateCategoryRamp( item ) );
-    }.bind( this ) );
+    }.bind(this));
 
     return style;
   },

--- a/src/widgets/auto-style/histogram.js
+++ b/src/widgets/auto-style/histogram.js
@@ -1,10 +1,12 @@
 var AutoStyler = require('./auto-styler');
+var StyleUtils = require('./style-utils');
+
 var HistogramAutoStyler = AutoStyler.extend({
   getStyle: function () {
     var style = this.layer.get('initialStyle');
     if (!style) return;
     ['marker-fill', 'polygon-fill', 'line-color'].forEach(function (item) {
-      style = style.replace(new RegExp('\\' + 's' + item + ':.*?;', 'g'), this.getColorLine(item));
+      style = StyleUtils.changeStyle(style, item, this.getColorLine(item));
     }.bind(this));
     return style;
   },

--- a/src/widgets/auto-style/style-utils.js
+++ b/src/widgets/auto-style/style-utils.js
@@ -7,7 +7,9 @@ function removeEmptyLayer (cartocss) {
 }
 
 function setFlagInCartocss (cartocss, attr, flag) {
-  return cartocss.replace(getAttrRegex(attr, false), flag);
+  var exist = cartocss.search(getAttrRegex(attr, false)) >= 0;
+
+  return exist ? cartocss.replace('{', '{ ' + flag) : cartocss;
 }
 
 function removeAttr (cartocss, attr) {

--- a/src/widgets/auto-style/style-utils.js
+++ b/src/widgets/auto-style/style-utils.js
@@ -1,0 +1,51 @@
+function getAttrRegex (attr, multi) {
+  return new RegExp('\\' + 's' + attr + ':.*?(;|\n)', multi ? 'g' : '');
+}
+
+function removeEmptyLayer (cartocss) {
+  return cartocss.replace(/[^;}{]*{((\s|\n)*?)}/g, '');
+}
+
+function setFlagInCartocss (cartocss, attr, flag) {
+  return cartocss.replace(getAttrRegex(attr, false), flag);
+}
+
+function removeAttr (cartocss, attr) {
+  return cartocss.replace(getAttrRegex(attr, true), '');
+}
+
+function insertCartoCSSAttribute (cartocss, attrib, flag) {
+  return cartocss.replace(flag, attrib);
+}
+
+function changeStyle (cartocss, attr, newStyle) {
+  var flag = '##' + attr + '##;';
+
+  return insertCartoCSSAttribute(
+            removeEmptyLayer(
+              removeAttr(
+                setFlagInCartocss(cartocss, attr, flag),
+                attr
+              )
+            ),
+
+            newStyle,
+            flag
+          );
+}
+
+module.exports = {
+
+  getAttrRegex: getAttrRegex,
+
+  removeEmptyLayer: removeEmptyLayer,
+
+  setFlagInCartocss: setFlagInCartocss,
+
+  removeAttr: removeAttr,
+
+  insertCartoCSSAttribute: insertCartoCSSAttribute,
+
+  changeStyle: changeStyle
+
+};

--- a/src/widgets/auto-style/style-utils.js
+++ b/src/widgets/auto-style/style-utils.js
@@ -18,6 +18,13 @@ function insertCartoCSSAttribute (cartocss, attrib, flag) {
   return cartocss.replace(flag, attrib);
 }
 
+/**
+ * Change attr style and remove all the duplicates
+ * @param  {String} cartocss cartocss original String
+ * @param  {String} attr     CSS Attribute ex, polygon-fill
+ * @param  {String} newStyle New attribute style ex, polygon-fill: red;
+ * @return {String}          Cartocss modified String
+ */
 function changeStyle (cartocss, attr, newStyle) {
   var flag = '##' + attr + '##;';
 
@@ -35,17 +42,5 @@ function changeStyle (cartocss, attr, newStyle) {
 }
 
 module.exports = {
-
-  getAttrRegex: getAttrRegex,
-
-  removeEmptyLayer: removeEmptyLayer,
-
-  setFlagInCartocss: setFlagInCartocss,
-
-  removeAttr: removeAttr,
-
-  insertCartoCSSAttribute: insertCartoCSSAttribute,
-
   changeStyle: changeStyle
-
 };


### PR DESCRIPTION
We are replacing the attrs in other way. This fix #457 issue.

- Mark the attr to change

- Remove all of them

- Remove empty layers or conditions

- Change the mark with the new value of the attr

I've put the functional code just above, but it is not reusable and this is not a good place for it. We have to move it to a better place aligned with the project architecture to allow reusability and a better understanding.

This is a temporal solution, waiting for a better one using cartocss parser.

NOTE: I have to add tests to this PR, don't merge! 🙂 

cc @javisantana & @alonsogarciapablo 