### PR TITLE
Get global distribution type to fix #468

### DIFF
--- a/spec/widgets/auto-style/histogram.js
+++ b/spec/widgets/auto-style/histogram.js
@@ -11,6 +11,7 @@ describe('src/widgets/auto-style/histogram', function () {
     });
 
     this.dataview.getDistributionType = jasmine.createSpy('disttype').and.returnValue('F');
+    this.dataview.getUnfilteredDataModel = jasmine.createSpy('disttype').and.returnValue(this.dataview);
     this.layer = this.dataview.layer = layer;
     this.histogramAutoStyler = new HistogramAutoStyler(this.dataview);
   });

--- a/src/widgets/auto-style/histogram.js
+++ b/src/widgets/auto-style/histogram.js
@@ -12,7 +12,9 @@ var HistogramAutoStyler = AutoStyler.extend({
   },
 
   getColorLine: function (sym) {
-    var shape = this.dataviewModel.getDistributionType();
+    var shape = this.dataviewModel.getDistributionType(
+      this.dataviewModel.getUnfilteredDataModel().get('data')
+    );
     var scales = HistogramAutoStyler.SCALES_MAP[sym][shape];
     return sym + ': ramp([' + this.dataviewModel.get('column') +
                  '], cartocolor(' + scales.palette + ', ' + this.dataviewModel.get('bins') +


### PR DESCRIPTION
This PR needs from this [other one.](https://github.com/CartoDB/cartodb.js/pull/1450)

It use global data to generate ramp color.
