### PR TITLE
Add opts.autoStyle flag

### DIFF
--- a/spec/widgets/auto-style.spec.js
+++ b/spec/widgets/auto-style.spec.js
@@ -11,7 +11,7 @@ describe('auto-style', function () {
     });
     this.widgetModel = new CategoryWidgetModel({}, {
       dataviewModel: this.dataviewModel
-    });
+    }, {autoStyleEnabled: true});
     this.autoStyler = this.widgetModel.autoStyler;
   });
 

--- a/spec/widgets/category/category-widget-model.spec.js
+++ b/spec/widgets/category/category-widget-model.spec.js
@@ -14,7 +14,7 @@ describe('widgets/category/category-widget-model', function () {
     });
     this.widgetModel = new CategoryWidgetModel({}, {
       dataviewModel: this.dataviewModel
-    });
+    }, {autoStyleEnabled: true});
   });
 
   describe('when model is set to collapsed', function () {

--- a/spec/widgets/category/item-view.spec.js
+++ b/spec/widgets/category/item-view.spec.js
@@ -11,7 +11,7 @@ describe('widgets/category/item-view', function () {
     });
     this.widgetModel = new CategoryWidgetModel({}, {
       dataviewModel: this.dataviewModel
-    });
+    }, {autoStyleEnabled: true});
     this.view = new ItemView({
       widgetModel: this.widgetModel,
       dataviewModel: this.dataviewModel,

--- a/spec/widgets/category/search-title-view.spec.js
+++ b/spec/widgets/category/search-title-view.spec.js
@@ -16,7 +16,7 @@ describe('widgets/category/search-title-view', function () {
     this.dataviewModel.layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
     this.widgetModel = new CategoryWidgetModel({}, {
       dataviewModel: this.dataviewModel
-    });
+    }, {autoStyleEnabled: true});
     this.view = new SearchTitleView({
       widgetModel: this.widgetModel,
       dataviewModel: this.dataviewModel

--- a/spec/widgets/category/search-title-view.spec.js
+++ b/spec/widgets/category/search-title-view.spec.js
@@ -14,106 +14,128 @@ describe('widgets/category/search-title-view', function () {
       column: 'col'
     });
     this.dataviewModel.layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
-    this.widgetModel = new CategoryWidgetModel({}, {
-      dataviewModel: this.dataviewModel
-    }, {autoStyleEnabled: true});
-    this.view = new SearchTitleView({
-      widgetModel: this.widgetModel,
-      dataviewModel: this.dataviewModel
-    });
   });
 
-  it('should render properly', function () {
-    this.view.render();
-    var $el = this.view.$el;
-    expect($el.find('.js-title').length).toBe(1);
-    expect($el.find('.CDB-Widget-options').length).toBe(1);
-    expect($el.find('.js-titleText').length).toBe(1);
-  });
-
-  describe('search', function () {
+  describe('with autoStyleEnabled as true', function () {
     beforeEach(function () {
-      this.widgetModel.toggleSearch();
+      this.widgetModel = new CategoryWidgetModel({}, {
+        dataviewModel: this.dataviewModel
+      }, {autoStyleEnabled: true});
+      this.view = new SearchTitleView({
+        widgetModel: this.widgetModel,
+        dataviewModel: this.dataviewModel
+      });
     });
 
-    it('should render search form properly', function () {
-      expect(this.view.$('.CDB-Widget-search').length).toBe(1);
-      expect(this.view.$('.js-searchIcon').length).toBe(1);
-      expect(this.view.$('.CDB-Widget-textInput').length).toBe(1);
-      expect(this.view.$('.CDB-Widget-searchApply').length).toBe(0);
-    });
-
-    it('should trigger search when text input changes', function () {
-      spyOn(this.dataviewModel, 'applySearch');
-      this.view.$('.js-textInput').val('ES');
-      this.view._onSubmitForm();
-      expect(this.dataviewModel.applySearch).toHaveBeenCalled();
-    });
-
-    it('should not trigger search when text input changes are not valid', function () {
-      spyOn(this.dataviewModel, 'applySearch');
-      this.view.$('.js-textInput').val('');
-      this.view._onSubmitForm();
-      expect(this.dataviewModel.applySearch).not.toHaveBeenCalled();
-    });
-
-    it('should not trigger search when text input changes are same as last search query value', function () {
-      spyOn(this.dataviewModel, 'applySearch');
-      this.dataviewModel.setSearchQuery('ES');
-      this.view.$('.js-textInput').val('ES');
-      this.view._onSubmitForm();
-      expect(this.dataviewModel.applySearch).not.toHaveBeenCalled();
-    });
-
-    it('should show apply button when there is any change to apply', function () {
-      this.dataviewModel.filter.accept('test');
-      expect(this.view.$('.CDB-Widget-searchApply').length).toBe(1);
-    });
-
-    it('should apply locked categories when apply button is clicked', function () {
-      spyOn(this.widgetModel, 'applyLocked');
-      this.dataviewModel.filter.accept('one');
-      this.view.$('.js-applyLocked').click();
-      expect(this.widgetModel.applyLocked).toHaveBeenCalled();
-    });
-  });
-
-  describe('options', function () {
-    beforeEach(function () {
+    it('should render properly', function () {
       this.view.render();
-    });
-
-    it('should render "apply colors" button and apply them when is clicked', function () {
+      var $el = this.view.$el;
+      expect($el.find('.js-title').length).toBe(1);
+      expect($el.find('.CDB-Widget-options').length).toBe(1);
+      expect($el.find('.js-titleText').length).toBe(1);
       expect(this.view.$('.js-autoStyle').length).toBe(1);
-      spyOn(this.widgetModel, 'autoStyle').and.callThrough();
-      this.view.$('.js-autoStyle').click();
-      expect(this.widgetModel.autoStyle).toHaveBeenCalled();
-      expect(this.view.$('.js-autoStyle').length).toBe(0);
-      expect(this.view.$('.js-cancelAutoStyle').length).toBe(1);
     });
 
-    it('should remove category colors when they are applied and button is clicked', function () {
-      spyOn(this.widgetModel, 'cancelAutoStyle').and.callThrough();
-      this.view.$('.js-autoStyle').click();
-      expect(this.view.$('.js-cancelAutoStyle').hasClass('is-selected')).toBeTruthy();
-      this.view.$('.js-cancelAutoStyle').click();
-      expect(this.widgetModel.cancelAutoStyle).toHaveBeenCalled();
-    });
-  });
+    describe('search', function () {
+      beforeEach(function () {
+        this.widgetModel.toggleSearch();
+      });
 
-  describe('allowed', function () {
-    beforeEach(function () {
-      this.view.render();
+      it('should render search form properly', function () {
+        expect(this.view.$('.CDB-Widget-search').length).toBe(1);
+        expect(this.view.$('.js-searchIcon').length).toBe(1);
+        expect(this.view.$('.CDB-Widget-textInput').length).toBe(1);
+        expect(this.view.$('.CDB-Widget-searchApply').length).toBe(0);
+      });
+
+      it('should trigger search when text input changes', function () {
+        spyOn(this.dataviewModel, 'applySearch');
+        this.view.$('.js-textInput').val('ES');
+        this.view._onSubmitForm();
+        expect(this.dataviewModel.applySearch).toHaveBeenCalled();
+      });
+
+      it('should not trigger search when text input changes are not valid', function () {
+        spyOn(this.dataviewModel, 'applySearch');
+        this.view.$('.js-textInput').val('');
+        this.view._onSubmitForm();
+        expect(this.dataviewModel.applySearch).not.toHaveBeenCalled();
+      });
+
+      it('should not trigger search when text input changes are same as last search query value', function () {
+        spyOn(this.dataviewModel, 'applySearch');
+        this.dataviewModel.setSearchQuery('ES');
+        this.view.$('.js-textInput').val('ES');
+        this.view._onSubmitForm();
+        expect(this.dataviewModel.applySearch).not.toHaveBeenCalled();
+      });
+
+      it('should show apply button when there is any change to apply', function () {
+        this.dataviewModel.filter.accept('test');
+        expect(this.view.$('.CDB-Widget-searchApply').length).toBe(1);
+      });
+
+      it('should apply locked categories when apply button is clicked', function () {
+        spyOn(this.widgetModel, 'applyLocked');
+        this.dataviewModel.filter.accept('one');
+        this.view.$('.js-applyLocked').click();
+        expect(this.widgetModel.applyLocked).toHaveBeenCalled();
+      });
     });
 
-    it('should remove button when not allowed', function () {
-      this.widgetModel.set('style', {auto_style: {allowed: false}});
-      expect(this.view.$('.js-autoStyle').length).toBe(0);
+    describe('options', function () {
+      beforeEach(function () {
+        this.view.render();
+      });
+
+      it('should render "apply colors" button and apply them when is clicked', function () {
+        expect(this.view.$('.js-autoStyle').length).toBe(1);
+        spyOn(this.widgetModel, 'autoStyle').and.callThrough();
+        this.view.$('.js-autoStyle').click();
+        expect(this.widgetModel.autoStyle).toHaveBeenCalled();
+        expect(this.view.$('.js-autoStyle').length).toBe(0);
+        expect(this.view.$('.js-cancelAutoStyle').length).toBe(1);
+      });
+
+      it('should remove category colors when they are applied and button is clicked', function () {
+        spyOn(this.widgetModel, 'cancelAutoStyle').and.callThrough();
+        this.view.$('.js-autoStyle').click();
+        expect(this.view.$('.js-cancelAutoStyle').hasClass('is-selected')).toBeTruthy();
+        this.view.$('.js-cancelAutoStyle').click();
+        expect(this.widgetModel.cancelAutoStyle).toHaveBeenCalled();
+      });
     });
 
-    it('should show button when allowed', function () {
-      this.widgetModel.set('style', {auto_style: {allowed: true}});
-      expect(this.view.$('.js-autoStyle').length).toBe(1);
+    describe('allowed', function () {
+      beforeEach(function () {
+        this.view.render();
+      });
+
+      it('should remove button when not allowed', function () {
+        this.widgetModel.set('style', {auto_style: {allowed: false}});
+        expect(this.view.$('.js-autoStyle').length).toBe(0);
+      });
+
+      it('should show button when allowed', function () {
+        this.widgetModel.set('style', {auto_style: {allowed: true}});
+        expect(this.view.$('.js-autoStyle').length).toBe(1);
+      });
+    });
+
+    describe('with autoStyleEnabled set to false', function () {
+      beforeEach(function () {
+        this.widgetModel = new CategoryWidgetModel({}, {
+          dataviewModel: this.dataviewModel
+        }, {autoStyleEnabled: false});
+        this.view = new SearchTitleView({
+          widgetModel: this.widgetModel,
+          dataviewModel: this.dataviewModel
+        });
+      });
+
+      it('should not render the autostyle button', function () {
+        expect(this.view.$('.js-autoStyle').length).toBe(0);
+      });
     });
   });
 

--- a/spec/widgets/histogram/histogram-widget-model.spec.js
+++ b/spec/widgets/histogram/histogram-widget-model.spec.js
@@ -9,7 +9,7 @@ describe('widgets/histogram/histogram-widget-model', function () {
     });
     this.widgetModel = new HistogramWidgetModel({}, {
       dataviewModel: this.dataviewModel
-    });
+    }, {autoStyleEnabled: true});
   });
 
   describe('when model is set to collapsed', function () {

--- a/spec/widgets/widget-model.spec.js
+++ b/spec/widgets/widget-model.spec.js
@@ -2,173 +2,218 @@ var specHelper = require('../spec-helper');
 var WidgetModel = require('../../src/widgets/widget-model');
 
 describe('widgets/widget-model', function () {
-  beforeEach(function () {
-    var vis = specHelper.createDefaultVis();
-    // Use a category dataview as example
-    var dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {
-      column: 'col'
-    });
-    dataviewModel.remove = spyOn(dataviewModel, 'remove');
-
-    this.model = new WidgetModel(null, {
-      dataviewModel: dataviewModel
-    }, {autoStyleEnabled: true});
-  });
-
-  describe('.update', function () {
+  describe('when autostyle options is enabled', function () {
     beforeEach(function () {
-      this.widgetChangeSpy = jasmine.createSpy('widgetModel change');
-      this.model.on('change', this.widgetChangeSpy);
+      var vis = specHelper.createDefaultVis();
+      // Use a category dataview as example
+      var dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {
+        column: 'col'
+      });
+      dataviewModel.remove = spyOn(dataviewModel, 'remove');
+
+      this.model = new WidgetModel(null, {
+        dataviewModel: dataviewModel
+      }, {autoStyleEnabled: true});
     });
 
-    describe('when given empty object', function () {
+    describe('.update', function () {
       beforeEach(function () {
-        this.result = this.model.update();
-        this.result = this.model.update({}) || this.result;
+        this.widgetChangeSpy = jasmine.createSpy('widgetModel change');
+        this.model.on('change', this.widgetChangeSpy);
       });
 
-      it('should return false since did not change anything', function () {
-        expect(this.result).toBe(false);
+      describe('when given empty object', function () {
+        beforeEach(function () {
+          this.result = this.model.update();
+          this.result = this.model.update({}) || this.result;
+        });
+
+        it('should return false since did not change anything', function () {
+          expect(this.result).toBe(false);
+        });
+
+        it('should not change anything', function () {
+          expect(this.widgetChangeSpy).not.toHaveBeenCalled();
+          expect(this.model.dataviewModel.changedAttributes()).toBe(false);
+        });
       });
 
-      it('should not change anything', function () {
-        expect(this.widgetChangeSpy).not.toHaveBeenCalled();
-        expect(this.model.dataviewModel.changedAttributes()).toBe(false);
+      describe('when there are some attrsNames but no dataview attrs names defined', function () {
+        beforeEach(function () {
+          this.model.set({
+            attrsNames: ['title']
+          }, { silent: true });
+          this.result = this.model.update({
+            title: 'new title',
+            column: 'col',
+            aggregation: 'count',
+            invalid: 'attr, should not be set'
+          });
+        });
+
+        it('should return true since attrs were changed', function () {
+          expect(this.result).toBe(true);
+        });
+
+        it('should update widget', function () {
+          expect(this.widgetChangeSpy).toHaveBeenCalled();
+        });
+
+        it('should have changed the valid attrs and leave the rest', function () {
+          expect(this.model.hasChanged('title')).toBe(true);
+        });
+
+        it('should not change existing attrs', function () {
+          expect(this.model.hasChanged('collapsed')).toBe(false);
+        });
+
+        it('should not set any invalid attrs', function () {
+          expect(this.model.get('invalid')).toBeUndefined();
+        });
+
+        it('should not update dataviewModel', function () {
+          expect(this.model.dataviewModel.changedAttributes()).toBe(false);
+        });
+      });
+
+      describe('when there are both widget and dataview attrs names defined', function () {
+        beforeEach(function () {
+          this.model.set({
+            attrsNames: ['title']
+          }, { silent: true });
+          this.result = this.model.update({
+            title: 'new title',
+            column: 'other',
+            aggregation: 'sum',
+            foo: 'attr, should not be set'
+          });
+        });
+
+        it('should return true since attrs were changed', function () {
+          expect(this.result).toBe(true);
+        });
+
+        it('should update the widget', function () {
+          expect(this.model.changedAttributes()).toEqual({
+            title: 'new title'
+          });
+        });
+
+        it('should update the dataview model attrs', function () {
+          expect(this.model.dataviewModel.changedAttributes()).toEqual({
+            column: 'other',
+            aggregation: 'sum'
+          });
+        });
       });
     });
 
-    describe('when there are some attrsNames but no dataview attrs names defined', function () {
+    describe('.remove', function () {
       beforeEach(function () {
-        this.model.set({
-          attrsNames: ['title']
-        }, { silent: true });
-        this.result = this.model.update({
-          title: 'new title',
-          column: 'col',
-          aggregation: 'count',
-          invalid: 'attr, should not be set'
-        });
+        this.removeSpy = jasmine.createSpy('remove');
+        spyOn(this.model, 'stopListening');
+        this.model.on('destroy', this.removeSpy);
+        this.model.remove();
       });
 
-      it('should return true since attrs were changed', function () {
-        expect(this.result).toBe(true);
+      it('should remove the model', function () {
+        expect(this.removeSpy).toHaveBeenCalledWith(this.model);
       });
 
-      it('should update widget', function () {
-        expect(this.widgetChangeSpy).toHaveBeenCalled();
+      it('should remove dataviewModel', function () {
+        expect(this.model.dataviewModel.remove).toHaveBeenCalled();
       });
 
-      it('should have changed the valid attrs and leave the rest', function () {
-        expect(this.model.hasChanged('title')).toBe(true);
-      });
-
-      it('should not change existing attrs', function () {
-        expect(this.model.hasChanged('collapsed')).toBe(false);
-      });
-
-      it('should not set any invalid attrs', function () {
-        expect(this.model.get('invalid')).toBeUndefined();
-      });
-
-      it('should not update dataviewModel', function () {
-        expect(this.model.dataviewModel.changedAttributes()).toBe(false);
+      it('should call stop listening to events', function () {
+        expect(this.model.stopListening).toHaveBeenCalled();
       });
     });
 
-    describe('when there are both widget and dataview attrs names defined', function () {
+    describe('getState', function () {
+      it('should only return states different from default', function () {
+        this.model.setState({
+          collapsed: true
+        });
+        expect(this.model.getState()).toEqual({collapsed: true});
+      });
+    });
+
+    describe('isAutoStyleEnabled', function () {
       beforeEach(function () {
-        this.model.set({
-          attrsNames: ['title']
-        }, { silent: true });
-        this.result = this.model.update({
-          title: 'new title',
-          column: 'other',
-          aggregation: 'sum',
-          foo: 'attr, should not be set'
-        });
+        this.model.set('type', 'category');
       });
 
-      it('should return true since attrs were changed', function () {
-        expect(this.result).toBe(true);
+      it('should return true without style options', function () {
+        expect(this.model.isAutoStyleEnabled()).toBe(true);
       });
 
-      it('should update the widget', function () {
-        expect(this.model.changedAttributes()).toEqual({
-          title: 'new title'
-        });
+      it('should return true with empty object style options', function () {
+        this.model.set('style', {});
+        expect(this.model.isAutoStyleEnabled()).toBe(true);
       });
 
-      it('should update the dataview model attrs', function () {
-        expect(this.model.dataviewModel.changedAttributes()).toEqual({
-          column: 'other',
-          aggregation: 'sum'
-        });
+      it('should return true with style options', function () {
+        var style = {
+          auto_style: {
+            allowed: true
+          }
+        };
+        this.model.set('style', style);
+        expect(this.model.isAutoStyleEnabled()).toBe(true);
+      });
+
+      it('should return false with style options', function () {
+        var style = {
+          auto_style: {
+            allowed: false
+          }
+        };
+        this.model.set('style', style);
+        expect(this.model.isAutoStyleEnabled()).toBe(false);
       });
     });
   });
 
-  describe('.remove', function () {
+  describe('when autostyle option is disabled', function () {
     beforeEach(function () {
-      this.removeSpy = jasmine.createSpy('remove');
-      spyOn(this.model, 'stopListening');
-      this.model.on('destroy', this.removeSpy);
-      this.model.remove();
-    });
-
-    it('should remove the model', function () {
-      expect(this.removeSpy).toHaveBeenCalledWith(this.model);
-    });
-
-    it('should remove dataviewModel', function () {
-      expect(this.model.dataviewModel.remove).toHaveBeenCalled();
-    });
-
-    it('should call stop listening to events', function () {
-      expect(this.model.stopListening).toHaveBeenCalled();
-    });
-  });
-
-  describe('getState', function () {
-    it('should only return states different from default', function () {
-      this.model.setState({
-        collapsed: true
+      var vis = specHelper.createDefaultVis();
+      // Use a category dataview as example
+      this.dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {
+        column: 'col'
       });
-      expect(this.model.getState()).toEqual({collapsed: true});
-    });
-  });
-
-  describe('isAutoStyleEnabled', function () {
-    beforeEach(function () {
-      this.model.set('type', 'category');
+      this.dataviewModel.remove = spyOn(this.dataviewModel, 'remove');
     });
 
-    it('should return true without style options', function () {
-      expect(this.model.isAutoStyleEnabled()).toBe(true);
-    });
+    describe('isAutoStyleEnabled', function () {
+      it('should be false if without autostyle option', function () {
+        var model = new WidgetModel(null, {
+          dataviewModel: this.dataviewModel
+        });
 
-    it('should return true with empty object style options', function () {
-      this.model.set('style', {});
-      expect(this.model.isAutoStyleEnabled()).toBe(true);
-    });
+        model.set('type', 'category');
 
-    it('should return true with style options', function () {
-      var style = {
-        auto_style: {
-          allowed: true
-        }
-      };
-      this.model.set('style', style);
-      expect(this.model.isAutoStyleEnabled()).toBe(true);
-    });
+        expect(model.isAutoStyleEnabled()).toBe(false);
+      });
 
-    it('should return false with style options', function () {
-      var style = {
-        auto_style: {
-          allowed: false
-        }
-      };
-      this.model.set('style', style);
-      expect(this.model.isAutoStyleEnabled()).toBe(false);
+      it('should be false if passed autostyle option as false', function () {
+        var model = new WidgetModel(null, {
+          dataviewModel: this.dataviewModel
+        }, {autoStyleEnabled: false});
+
+        model.set('type', 'category');
+
+        expect(model.isAutoStyleEnabled()).toBe(false);
+      });
+
+      it('should be true if passed autostyle option as true', function () {
+        var model = new WidgetModel(null, {
+          dataviewModel: this.dataviewModel
+        }, {autoStyleEnabled: true});
+
+        model.set('type', 'category');
+
+        expect(model.isAutoStyleEnabled()).toBe(true);
+      });
     });
   });
 });

--- a/spec/widgets/widget-model.spec.js
+++ b/spec/widgets/widget-model.spec.js
@@ -12,7 +12,7 @@ describe('widgets/widget-model', function () {
 
     this.model = new WidgetModel(null, {
       dataviewModel: dataviewModel
-    });
+    }, {autoStyleEnabled: true});
   });
 
   describe('.update', function () {

--- a/src/api/create-dashboard.js
+++ b/src/api/create-dashboard.js
@@ -26,6 +26,9 @@ var createDashboard = function (selector, vizJSON, opts, callback) {
   opts.renderMenu = _.isBoolean(opts.renderMenu)
     ? opts.renderMenu
     : true;
+  opts.autoStyle = _.isBoolean(opts.autoStyle)
+    ? opts.autoStyle
+    : false;
 
   var widgets = new WidgetsCollection();
 
@@ -84,6 +87,7 @@ var createDashboard = function (selector, vizJSON, opts, callback) {
       var newWidgetModel = widgetModelsMap[d.type];
       var state = widgetsState[d.id];
 
+      attrs = opts.autoStyle ? attrs : _.extend(attrs, {style: {auto_style: {allowed: false}}});
       if (_.isFunction(newWidgetModel)) {
         // Find the Layer that the Widget should be created for.
         var layer;

--- a/src/api/create-dashboard.js
+++ b/src/api/create-dashboard.js
@@ -40,6 +40,7 @@ var createDashboard = function (selector, vizJSON, opts, callback) {
     userProfileURL: vizJSON.user.profile_url,
     userAvatarURL: vizJSON.user.avatar_url,
     renderMenu: opts.renderMenu,
+    autoStyle: opts.autoStyle,
     showLogo: opts.cartodb_logo,
     initialPosition: {
       bounds: vizJSON.bounds
@@ -83,11 +84,10 @@ var createDashboard = function (selector, vizJSON, opts, callback) {
     };
     vizJSON.widgets.forEach(function (d) {
       // Flatten the data structure given in vizJSON, the widgetsService will use whatever it needs and ignore the rest
-      var attrs = _.extend({}, d, d.options);
+      var attrs = _.extend({}, d, d.options, {autoStyleEnabled: opts.autoStyle});
       var newWidgetModel = widgetModelsMap[d.type];
       var state = widgetsState[d.id];
 
-      attrs = opts.autoStyle ? attrs : _.extend(attrs, {style: {auto_style: {allowed: false}}});
       if (_.isFunction(newWidgetModel)) {
         // Find the Layer that the Widget should be created for.
         var layer;

--- a/src/api/create-dashboard.js
+++ b/src/api/create-dashboard.js
@@ -84,7 +84,7 @@ var createDashboard = function (selector, vizJSON, opts, callback) {
     };
     vizJSON.widgets.forEach(function (d) {
       // Flatten the data structure given in vizJSON, the widgetsService will use whatever it needs and ignore the rest
-      var attrs = _.extend({}, d, d.options, {autoStyleEnabled: opts.autoStyle});
+      var attrs = _.extend({}, d, d.options);
       var newWidgetModel = widgetModelsMap[d.type];
       var state = widgetsState[d.id];
 
@@ -99,7 +99,7 @@ var createDashboard = function (selector, vizJSON, opts, callback) {
           layer = vis.map.layers.at(d.layerIndex);
         }
 
-        newWidgetModel(attrs, layer, state);
+        newWidgetModel(attrs, layer, state, {autoStyleEnabled: opts.autoStyle});
       } else {
         cdb.log.error('No widget found for type ' + d.type);
       }

--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -72,12 +72,13 @@ Dashboard.prototype = {
     }, this);
   },
 
-  _addAutoStyleOpt: function (attrs) {
+  _getAutoStyleOpt: function (opts) {
     var autoStyleEnabled = this._dashboard.dashboardView.model.get('autoStyle');
 
-    attrs.autoStyleEnabled = autoStyleEnabled || false;
+    opts = opts || {};
+    opts.autoStyleEnabled = autoStyleEnabled || false;
 
-    return attrs;
+    return opts;
   },
 
   /**
@@ -98,7 +99,7 @@ Dashboard.prototype = {
    * @return {CategoryWidget} The new widget
    */
   createCategoryWidget: function (widgetAttrs, layer) {
-    return this._dashboard.widgets.createCategoryModel(this._addAutoStyleOpt(widgetAttrs), layer);
+    return this._dashboard.widgets.createCategoryModel(widgetAttrs, layer, null, this._getAutoStyleOpt());
   },
 
   /**
@@ -111,7 +112,7 @@ Dashboard.prototype = {
    * @return {HistogramWidget} The new widget
    */
   createHistogramWidget: function (widgetAttrs, layer) {
-    return this._dashboard.widgets.createHistogramModel(this._addAutoStyleOpt(widgetAttrs), layer);
+    return this._dashboard.widgets.createHistogramModel(widgetAttrs, layer, null, this._getAutoStyleOpt());
   },
 
   /**
@@ -124,7 +125,7 @@ Dashboard.prototype = {
    * @return {FormulaWidget} The new widget
    */
   createFormulaWidget: function (widgetAttrs, layer) {
-    return this._dashboard.widgets.createFormulaModel(this._addAutoStyleOpt(widgetAttrs), layer);
+    return this._dashboard.widgets.createFormulaModel(widgetAttrs, layer, null, this._getAutoStyleOpt());
   },
 
   /**
@@ -137,7 +138,7 @@ Dashboard.prototype = {
    * @return {TimeSeriesWidget} The new widget
    */
   createTimeSeriesWidget: function (widgetAttrs, layer) {
-    return this._dashboard.widgets.createTimeSeriesModel(this._addAutoStyleOpt(widgetAttrs), layer);
+    return this._dashboard.widgets.createTimeSeriesModel(widgetAttrs, layer, null, this._getAutoStyleOpt());
   }
 
 };

--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -72,6 +72,14 @@ Dashboard.prototype = {
     }, this);
   },
 
+  _addAutoStyleOpt: function (attrs) {
+    var autoStyleEnabled = this._dashboard.dashboardView.model.get('autoStyle');
+
+    attrs.autoStyleEnabled = autoStyleEnabled || false;
+
+    return attrs;
+  },
+
   /**
    * @param {Integer} id - widget id
    * @return a widget object
@@ -90,7 +98,7 @@ Dashboard.prototype = {
    * @return {CategoryWidget} The new widget
    */
   createCategoryWidget: function (widgetAttrs, layer) {
-    return this._dashboard.widgets.createCategoryModel(widgetAttrs, layer);
+    return this._dashboard.widgets.createCategoryModel(this._addAutoStyleOpt(widgetAttrs), layer);
   },
 
   /**
@@ -103,7 +111,7 @@ Dashboard.prototype = {
    * @return {HistogramWidget} The new widget
    */
   createHistogramWidget: function (widgetAttrs, layer) {
-    return this._dashboard.widgets.createHistogramModel(widgetAttrs, layer);
+    return this._dashboard.widgets.createHistogramModel(this._addAutoStyleOpt(widgetAttrs), layer);
   },
 
   /**
@@ -116,7 +124,7 @@ Dashboard.prototype = {
    * @return {FormulaWidget} The new widget
    */
   createFormulaWidget: function (widgetAttrs, layer) {
-    return this._dashboard.widgets.createFormulaModel(widgetAttrs, layer);
+    return this._dashboard.widgets.createFormulaModel(this._addAutoStyleOpt(widgetAttrs), layer);
   },
 
   /**
@@ -129,7 +137,7 @@ Dashboard.prototype = {
    * @return {TimeSeriesWidget} The new widget
    */
   createTimeSeriesWidget: function (widgetAttrs, layer) {
-    return this._dashboard.widgets.createTimeSeriesModel(widgetAttrs, layer);
+    return this._dashboard.widgets.createTimeSeriesModel(this._addAutoStyleOpt(widgetAttrs), layer);
   }
 
 };

--- a/src/widgets-service.js
+++ b/src/widgets-service.js
@@ -36,7 +36,7 @@ WidgetsService.prototype.createCategoryModel = function (attrs, layer, state) {
   attrs = _.extend(attrs, state); // Will overwrite preset attributes with the ones passed on the state
   var dataviewModel = this._dataviews.createCategoryModel(layer, attrs);
 
-  var attrsNames = ['id', 'title', 'order', 'collapsed', 'prefix', 'suffix', 'show_stats', 'style'];
+  var attrsNames = ['id', 'title', 'order', 'collapsed', 'prefix', 'suffix', 'show_stats', 'style', 'autoStyleEnabled'];
   var widgetAttrs = _.pick(attrs, attrsNames);
   widgetAttrs.attrsNames = attrsNames;
 
@@ -62,7 +62,7 @@ WidgetsService.prototype.createHistogramModel = function (attrs, layer, state) {
   var dataAttrs = _.extend(attrs, state); // Will overwrite preset attributes with the ones passed on the state
   var dataviewModel = this._dataviews.createHistogramModel(layer, dataAttrs);
 
-  var attrsNames = ['id', 'title', 'order', 'collapsed', 'bins', 'show_stats', 'normalized', 'style'];
+  var attrsNames = ['id', 'title', 'order', 'collapsed', 'bins', 'show_stats', 'normalized', 'style', 'autoStyleEnabled'];
   var widgetAttrs = _.pick(attrs, attrsNames);
   widgetAttrs.type = 'histogram';
   widgetAttrs.attrsNames = attrsNames;
@@ -141,7 +141,7 @@ WidgetsService.prototype.createTimeSeriesModel = function (attrs, layer, state) 
   attrs.column_type = attrs.column_type || 'date';
   var dataviewModel = this._dataviews.createHistogramModel(layer, attrs);
 
-  var attrsNames = ['id', 'style'];
+  var attrsNames = ['id', 'style', 'autoStyleEnabled'];
   var widgetAttrs = _.pick(attrs, attrsNames);
   widgetAttrs.type = 'time-series';
   widgetAttrs.attrsNames = attrsNames;

--- a/src/widgets-service.js
+++ b/src/widgets-service.js
@@ -31,18 +31,18 @@ WidgetsService.prototype.getList = function () {
  * @param {Object} layer Instance of a layer model (cartodb.js)
  * @return {CategoryWidgetModel}
  */
-WidgetsService.prototype.createCategoryModel = function (attrs, layer, state) {
+WidgetsService.prototype.createCategoryModel = function (attrs, layer, state, opts) {
   _checkProperties(attrs, ['title']);
   attrs = _.extend(attrs, state); // Will overwrite preset attributes with the ones passed on the state
   var dataviewModel = this._dataviews.createCategoryModel(layer, attrs);
 
-  var attrsNames = ['id', 'title', 'order', 'collapsed', 'prefix', 'suffix', 'show_stats', 'style', 'autoStyleEnabled'];
+  var attrsNames = ['id', 'title', 'order', 'collapsed', 'prefix', 'suffix', 'show_stats', 'style'];
   var widgetAttrs = _.pick(attrs, attrsNames);
   widgetAttrs.attrsNames = attrsNames;
 
   var widgetModel = new CategoryWidgetModel(widgetAttrs, {
     dataviewModel: dataviewModel
-  });
+  }, opts);
   widgetModel.setState(state);
   this._widgetsCollection.add(widgetModel);
 
@@ -57,19 +57,19 @@ WidgetsService.prototype.createCategoryModel = function (attrs, layer, state) {
  * @param {Object} layer Instance of a layer model (cartodb.js)
  * @return {WidgetModel}
  */
-WidgetsService.prototype.createHistogramModel = function (attrs, layer, state) {
+WidgetsService.prototype.createHistogramModel = function (attrs, layer, state, opts) {
   _checkProperties(attrs, ['title']);
   var dataAttrs = _.extend(attrs, state); // Will overwrite preset attributes with the ones passed on the state
   var dataviewModel = this._dataviews.createHistogramModel(layer, dataAttrs);
 
-  var attrsNames = ['id', 'title', 'order', 'collapsed', 'bins', 'show_stats', 'normalized', 'style', 'autoStyleEnabled'];
+  var attrsNames = ['id', 'title', 'order', 'collapsed', 'bins', 'show_stats', 'normalized', 'style'];
   var widgetAttrs = _.pick(attrs, attrsNames);
   widgetAttrs.type = 'histogram';
   widgetAttrs.attrsNames = attrsNames;
 
   var widgetModel = new HistogramWidgetModel(widgetAttrs, {
     dataviewModel: dataviewModel
-  });
+  }, opts);
   widgetModel.setState(state);
   this._widgetsCollection.add(widgetModel);
 
@@ -136,19 +136,19 @@ WidgetsService.prototype.createListModel = function (attrs, layer) {
  * @param {Number} bins
  * @return {WidgetModel}
  */
-WidgetsService.prototype.createTimeSeriesModel = function (attrs, layer, state) {
+WidgetsService.prototype.createTimeSeriesModel = function (attrs, layer, state, opts) {
   // TODO will other kind really work for a time-series?
   attrs.column_type = attrs.column_type || 'date';
   var dataviewModel = this._dataviews.createHistogramModel(layer, attrs);
 
-  var attrsNames = ['id', 'style', 'autoStyleEnabled'];
+  var attrsNames = ['id', 'style'];
   var widgetAttrs = _.pick(attrs, attrsNames);
   widgetAttrs.type = 'time-series';
   widgetAttrs.attrsNames = attrsNames;
 
   var widgetModel = new TimeSeriesWidgetModel(widgetAttrs, {
     dataviewModel: dataviewModel
-  });
+  }, opts);
   widgetModel.setState(state);
   this._widgetsCollection.add(widgetModel);
 

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -268,7 +268,8 @@ module.exports = cdb.core.View.extend({
 
   _onMouseOut: function () {
     var bars = this.chart.selectAll('.CDB-Chart-bar');
-    bars.classed('is-highlighted', false);
+    bars.classed('is-highlighted', false)
+        .attr('fill', this.options.chartBarColor);
     this.trigger('hover', { value: null });
   },
 
@@ -311,9 +312,11 @@ module.exports = cdb.core.View.extend({
     this.trigger('hover', hoverProperties);
 
     this.chart.selectAll('.CDB-Chart-bar')
-      .classed('is-highlighted', false);
+      .classed('is-highlighted', false)
+      .attr('fill', this.options.chartBarColor);
 
     if (bar && bar.node()) {
+      bar.attr('fill', this._getHoverColor());
       bar.classed('is-highlighted', true);
     }
   },
@@ -944,8 +947,6 @@ module.exports = cdb.core.View.extend({
     var bars = this.chart.selectAll('.CDB-Chart-bar')
       .data(data);
 
-    this._addHoverToStylesheet();
-
     bars
       .enter()
       .append('rect')
@@ -1000,25 +1001,8 @@ module.exports = cdb.core.View.extend({
       });
   },
 
-  _addHoverToStylesheet: function () {
-    var color = tinycolor(this.options.chartBarColor).darken().toString();
-    var sheets = document.styleSheets;
-    var sheet;
-    var rules;
-
-    for (var i = 0; i < sheets.length; i++) {
-      sheet = sheets[i];
-      if (sheet.cssRules) {
-        rules = sheet.cssRules;
-        break;
-      }
-    }
-
-    if (!rules || rules[0].selectorText !== '.CDB-Chart-bar.is-highlighted') {
-      sheet.insertRule('.CDB-Chart-bar.is-highlighted { fill: ' + color + ' !important; }', 0);
-    } else {
-      rules[0].style.fill = color;
-    }
+  _getHoverColor: function () {
+    return tinycolor(this.options.chartBarColor).darken().toString();
   },
 
   _generateBars: function () {
@@ -1026,7 +1010,6 @@ module.exports = cdb.core.View.extend({
     var data = this.model.get('data');
 
     this._calcBarWidth();
-    this._addHoverToStylesheet();
 
     var bars = this.chart.append('g')
       .attr('transform', 'translate(0, 0)')

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -56,6 +56,8 @@ module.exports = cdb.core.Model.extend({
   },
 
   isAutoStyleEnabled: function () {
+    if (!this.get('autoStyleEnabled')) return false;
+
     var styles = this.get('style');
 
     if ((!styles || !styles.auto_style) && (this.get('type') === 'category' || this.get('type') === 'histogram')) return true;

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -19,8 +19,10 @@ module.exports = cdb.core.Model.extend({
     'collapsed': false
   },
 
-  initialize: function (attrs, opts) {
-    this.dataviewModel = opts.dataviewModel;
+  initialize: function (attrs, models, opts) {
+    opts = opts || {};
+    this.dataviewModel = models.dataviewModel;
+    this.defaults.autoStyleEnabled = opts.autoStyleEnabled;
 
     this.activeAutoStyler();
     this.bind('change:style', this.activeAutoStyler, this);
@@ -56,7 +58,7 @@ module.exports = cdb.core.Model.extend({
   },
 
   isAutoStyleEnabled: function () {
-    if (!this.get('autoStyleEnabled')) return false;
+    if (!this.defaults.autoStyleEnabled) return false;
 
     var styles = this.get('style');
 
@@ -74,7 +76,7 @@ module.exports = cdb.core.Model.extend({
   },
 
   getColor: function (name) {
-    if (this.isAutoStyleEnabled() && this.isAutoStyle()) {
+    if (this.isAutoStyleEnabled() && this.isAutoStyle() && this.get('type') === 'category') {
       return this.autoStyler.colors.getColorByCategory(name);
     } else {
       return this.getWidgetColor();


### PR DESCRIPTION
This PR allow deactivate the autostyle button from widgets with the `autoStyle` flag passed as option to createDashboard function.

If this option is not present, the autoStyle feature is disabled by default.