### PR TITLE
Track if dataviewsFetched happened already when adding new widgets.

### DIFF
--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -58,6 +58,7 @@ Dashboard.prototype = {
 
   onStateChanged: function (callback, shareURLs) {
     this._dashboard.vis.once('dataviewsFetched', function () {
+      this._dashboard.widgets._widgetsCollection.initialState();
       this._dashboard.widgets._widgetsCollection.each(function (m) {
         m.applyInitialState();
       }, this);

--- a/src/widgets-service.js
+++ b/src/widgets-service.js
@@ -33,10 +33,10 @@ WidgetsService.prototype.getList = function () {
  */
 WidgetsService.prototype.createCategoryModel = function (attrs, layer, state, opts) {
   _checkProperties(attrs, ['title']);
-  attrs = _.extend(attrs, state); // Will overwrite preset attributes with the ones passed on the state
+  attrs = _.extend(attrs, state, {hasInitialState: this._widgetsCollection.hasInitialState()}); // Will overwrite preset attributes with the ones passed on the state
   var dataviewModel = this._dataviews.createCategoryModel(layer, attrs);
 
-  var attrsNames = ['id', 'title', 'order', 'collapsed', 'prefix', 'suffix', 'show_stats', 'style'];
+  var attrsNames = ['id', 'title', 'order', 'collapsed', 'prefix', 'suffix', 'show_stats', 'style', 'hasInitialState'];
   var widgetAttrs = _.pick(attrs, attrsNames);
   widgetAttrs.attrsNames = attrsNames;
 
@@ -59,10 +59,10 @@ WidgetsService.prototype.createCategoryModel = function (attrs, layer, state, op
  */
 WidgetsService.prototype.createHistogramModel = function (attrs, layer, state, opts) {
   _checkProperties(attrs, ['title']);
-  var dataAttrs = _.extend(attrs, state); // Will overwrite preset attributes with the ones passed on the state
+  var dataAttrs = _.extend(attrs, state, {hasInitialState: this._widgetsCollection.hasInitialState()}); // Will overwrite preset attributes with the ones passed on the state
   var dataviewModel = this._dataviews.createHistogramModel(layer, dataAttrs);
 
-  var attrsNames = ['id', 'title', 'order', 'collapsed', 'bins', 'show_stats', 'normalized', 'style'];
+  var attrsNames = ['id', 'title', 'order', 'collapsed', 'bins', 'show_stats', 'normalized', 'style', 'hasInitialState'];
   var widgetAttrs = _.pick(attrs, attrsNames);
   widgetAttrs.type = 'histogram';
   widgetAttrs.attrsNames = attrsNames;
@@ -86,10 +86,10 @@ WidgetsService.prototype.createHistogramModel = function (attrs, layer, state, o
  */
 WidgetsService.prototype.createFormulaModel = function (attrs, layer, state) {
   _checkProperties(attrs, ['title']);
-  attrs = _.extend(attrs, state); // Will overwrite preset attributes with the ones passed on the state
+  attrs = _.extend(attrs, state, {hasInitialState: this._widgetsCollection.hasInitialState()}); // Will overwrite preset attributes with the ones passed on the state
   var dataviewModel = this._dataviews.createFormulaModel(layer, attrs);
 
-  var attrsNames = ['id', 'title', 'order', 'collapsed', 'prefix', 'suffix', 'show_stats', 'description'];
+  var attrsNames = ['id', 'title', 'order', 'collapsed', 'prefix', 'suffix', 'show_stats', 'description', 'hasInitialState'];
   var widgetAttrs = _.pick(attrs, attrsNames);
   widgetAttrs.type = 'formula';
   widgetAttrs.attrsNames = attrsNames;

--- a/src/widgets/widgets-collection.js
+++ b/src/widgets/widgets-collection.js
@@ -8,6 +8,7 @@ module.exports = Backbone.Collection.extend({
   comparator: 'order',
 
   initialize: function () {
+    this._allDataviewsFetched = false;
     this._initBinds();
   },
 
@@ -48,5 +49,13 @@ module.exports = Backbone.Collection.extend({
       var widget = this.at(i);
       widget.setState(states[i]);
     }
+  },
+
+  hasInitialState: function () {
+    return this._allDataviewsFetched;
+  },
+
+  initialState: function () {
+    this._allDataviewsFetched = true;
   }
 });


### PR DESCRIPTION
In order to trigger the bindings properly when adding new widgets, we need to check if the initial
dataviews instantiation has already happened. In this scenario, we need to apply bindings without
waiting this event.

CR @donflopez 

cc @saleiva @javisantana 