### PR TITLE
Autostyle fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "backbone": "1.2.3",
     "cartocolor": "4.0.0",
-    "cartodb.js": "CartoDB/cartodb.js#v4",
+    "cartodb.js": "CartoDB/cartodb.js#remove-dataview-filter",
     "d3": "3.5.17",
     "jquery": "2.1.4",
     "moment": "2.10.6",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "backbone": "1.2.3",
     "cartocolor": "4.0.0",
-    "cartodb.js": "CartoDB/cartodb.js#remove-dataview-filter",
+    "cartodb.js": "CartoDB/cartodb.js#v4",
     "d3": "3.5.17",
     "jquery": "2.1.4",
     "moment": "2.10.6",

--- a/spec/widgets/auto-style/histogram.js
+++ b/spec/widgets/auto-style/histogram.js
@@ -16,6 +16,33 @@ describe('src/widgets/auto-style/histogram', function () {
     this.histogramAutoStyler = new HistogramAutoStyler(this.dataview);
   });
 
+  describe('.getDef', function () {
+    it('should generate ramps correctly', function () {
+      var styles = {
+        custom: false
+      };
+      this.histogramAutoStyler.styles = styles;
+      var definition = this.histogramAutoStyler.getDef('#layer {  marker-width: 6;  marker-fill: #e49115;}');
+      expect(definition.point).toBeDefined();
+      expect(definition.point.color.range.length).toBe(7);
+    });
+
+    it('should take into account custom ramps', function () {
+      var styles = {
+        custom: true,
+        definition: {
+          color: {
+            range: ['#fadaba', '#fff']
+          }
+        }
+      };
+      this.histogramAutoStyler.styles = styles;
+      var definition = this.histogramAutoStyler.getDef('#layer {  marker-width: 6;  marker-fill: #e49115;}');
+      expect(definition.point).toBeDefined();
+      expect(definition.point.color.range.length).toBe(2);
+    });
+  });
+
   describe('.getStyle', function () {
     it('should generate the right styles when layer has polygons', function () {
       this.dataview.layer.set('initialStyle', '#layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1;  polygon-fill: #e49115;  polygon-fill-opacity: 0.9; }');

--- a/src/widgets/auto-style/category.js
+++ b/src/widgets/auto-style/category.js
@@ -27,10 +27,12 @@ module.exports = AutoStyler.extend({
     var definitions = {};
 
     ['marker-fill', 'polygon-fill', 'line-color'].forEach(function (item) {
+      var definition = {};
       var geom = item.substring(0, item.indexOf('-'));
-      definitions[geom === 'marker' ? 'point' : geom] = { color:
+      definition = { color:
         { domain: _.pluck(categories, 'name'), range: range, attribute: model.get('column') }
       };
+      definitions[geom === 'marker' ? 'point' : geom] = definition;
     });
 
     return definitions;

--- a/src/widgets/auto-style/histogram.js
+++ b/src/widgets/auto-style/histogram.js
@@ -1,6 +1,7 @@
 var AutoStyler = require('./auto-styler');
 var StyleUtils = require('./style-utils');
 var cartocolor = require('cartocolor');
+var _ = require('underscore');
 
 var HistogramAutoStyler = AutoStyler.extend({
   getStyle: function () {
@@ -48,19 +49,27 @@ var HistogramAutoStyler = AutoStyler.extend({
     );
     var bins = this.dataviewModel.get('bins');
     var attr = this.dataviewModel.get('column');
+    var styles = this.styles;
+    var isCustomDefinition = this.styles.custom;
 
     ['marker-fill', 'polygon-fill', 'line-color'].forEach(function (item) {
       if (cartocss.search(StyleUtils.getAttrRegex(item, false)) >= 0) {
         var scales = HistogramAutoStyler.SCALES_MAP[item][shape];
         var geom = item.substring(0, item.indexOf('-'));
+        var definition = {};
+        if (isCustomDefinition === true) {
+          definition = _.extend(definition, styles.definition);
+        } else {
+          definition = {
+            color: {
+              range: cartocolor[scales.palette][bins] || cartocolor[scales.palette][Object.keys(cartocolor[scales.palette]).length],
+              quantification: scales.quantification,
+              attribute: attr
+            }
+          };
+        }
 
-        definitions[geom === 'marker' ? 'point' : geom] = {
-          color: {
-            range: cartocolor[scales.palette][bins] || cartocolor[scales.palette][Object.keys(cartocolor[scales.palette]).length],
-            quantification: scales.quantification,
-            attribute: attr
-          }
-        };
+        definitions[geom === 'marker' ? 'point' : geom] = definition;
       }
     });
 

--- a/src/widgets/category/category-widget-model.js
+++ b/src/widgets/category/category-widget-model.js
@@ -74,8 +74,8 @@ module.exports = WidgetModel.extend({
     WidgetModel.prototype.autoStyle.call(this);
   },
 
-  _updateColors: function (e) {
-    this.autoStyler.colors.updateColors(e.changed.style && e.changed.style.auto_style);
+  _updateColors: function (m, style) {
+    this.autoStyler.colors.updateColors(style.auto_style);
     this.autoStyler.colors.updateData(_.pluck(this.dataviewModel.get('data'), 'name'));
     if (this.isAutoStyle()) {
       this.reapplyAutoStyle();

--- a/src/widgets/histogram/histogram-widget-model.js
+++ b/src/widgets/histogram/histogram-widget-model.js
@@ -32,10 +32,9 @@ module.exports = WidgetModel.extend({
     this.dataviewModel.set('enabled', !isCollapsed);
   },
 
-  _updateAutoStyle: function (e) {
-    var styles = (e && e.changed && e.changed.style) || this.get('style');
+  _updateAutoStyle: function (m, style) {
     if (this.autoStyler) {
-      this.autoStyler.updateColors(styles);
+      this.autoStyler.updateColors(style);
     }
     if (this.isAutoStyle()) {
       this.reapplyAutoStyle();

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -28,9 +28,8 @@ module.exports = cdb.core.Model.extend({
     this.bind('change:style', this.activeAutoStyler, this);
   },
 
-  activeAutoStyler: function (e) {
-    var style = e && e.changed && e.changed.style;
-    if (this.isAutoStyleEnabled(style) && !this.autoStyler) {
+  activeAutoStyler: function () {
+    if (this.isAutoStyleEnabled() && !this.autoStyler) {
       this.autoStyler = AutoStylerFactory.get(this.dataviewModel, this.get('style'));
     }
   },
@@ -91,14 +90,11 @@ module.exports = cdb.core.Model.extend({
     if (!this.isAutoStyleEnabled()) return;
 
     var layer = this.dataviewModel.layer;
-
-    if (!layer.get('initialStyle')) {
-      var initialStyle = layer.get('cartocss');
-      if (!initialStyle && layer.get('meta')) {
-        initialStyle = layer.get('meta').cartocss;
-      }
-      layer.set('initialStyle', initialStyle);
+    var initialStyle = layer.get('cartocss');
+    if (!initialStyle && layer.get('meta')) {
+      initialStyle = layer.get('meta').cartocss;
     }
+    layer.set('initialStyle', initialStyle);
 
     var style = this.autoStyler.getStyle();
     layer.set('cartocss', style);

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -44,7 +44,18 @@ module.exports = cdb.core.Model.extend({
     var wAttrs = _.pick(attrs, this.get('attrsNames'));
     this.set(wAttrs);
     this.dataviewModel.update(attrs);
+    this._triggerChangesInAutoStyle();
     return !!(this.changedAttributes() || this.dataviewModel.changedAttributes());
+  },
+
+  _triggerChangesInAutoStyle: function () {
+    var changed = this.changed && this.changed.style && this.changed.style.auto_style && this.changed.style.auto_style.definition;
+    var previous = this.previousAttributes();
+    var former = previous.style && previous.style.auto_style && previous.style.auto_style.definition;
+
+    if (!_.isEqual(changed, former)) {
+      this.trigger('customAutoStyle', this);
+    }
   },
 
   /**
@@ -119,9 +130,8 @@ module.exports = cdb.core.Model.extend({
     var cartocss = this.dataviewModel.layer.get('cartocss');
 
     if (style && style.auto_style && style.auto_style.definition) {
-      var toRet = _.extend(style.auto_style, {cartocss: this.dataviewModel.layer.get('cartocss')});
-
-      return _.extend(toRet, {definition: this.autoStyler.getDef(cartocss)});
+      var toRet = _.extend(style.auto_style, {cartocss: cartocss});
+      return _.extend({}, toRet, {definition: this.autoStyler.getDef(cartocss)});
     } else {
       return {
         definition: this.autoStyler.getDef(cartocss),


### PR DESCRIPTION
This PR includes some auto style fixes. Also it cleans some code not used.

- Styling from widget removes variable size when having a point layer styled by size and color (https://github.com/CartoDB/cartodb/issues/11084): fixed by https://github.com/CartoDB/deep-insights.js/commit/bc26150b08725f7d75fc322a13ea00e8fa8e6394
- Custom ramp value is not correctly reflected on the style panel (https://github.com/CartoDB/cartodb/issues/11085) fixed by https://github.com/CartoDB/deep-insights.js/pull/502/commits/237d8b149d8d7c754d1ffa5c02dc2a5417260f08. When generating definition for histograms we are not taking account of custom ramps defined by the user. Also, we are triggering an event, so the Builder is aware a custom ramp for autostyle is applied and transmit the changes to the style definition model.

cc @xavijam @donflopez 

Please, don't merge until the package.json is fixed to point the right version of cartodb.js. Right now we are using it for staging proposes.
