### PR TITLE
Make sure styles exist when checking it's custom.

### DIFF
--- a/src/widgets/auto-style/histogram.js
+++ b/src/widgets/auto-style/histogram.js
@@ -50,7 +50,7 @@ var HistogramAutoStyler = AutoStyler.extend({
     var bins = this.dataviewModel.get('bins');
     var attr = this.dataviewModel.get('column');
     var styles = this.styles;
-    var isCustomDefinition = this.styles.custom;
+    var isCustomDefinition = this.styles && this.styles.custom || false;
 
     ['marker-fill', 'polygon-fill', 'line-color'].forEach(function (item) {
       if (cartocss.search(StyleUtils.getAttrRegex(item, false)) >= 0) {


### PR DESCRIPTION
This PR fixes a minor issue for histogram and autostyle. For old widgets (before new auto style), the custom style doesn't exist, so we need to check if exists before to test it's custom.