### PR TITLE
Represent auto-style colors 

### DIFF
--- a/examples/dynamic_widgets.html
+++ b/examples/dynamic_widgets.html
@@ -22,39 +22,41 @@
 
   <script>
     window.onload = function() {
-      var vizJSON = 'https://editor3.carto.com/api/v3/viz/94a4362c-491f-11e6-a764-0e233c30368f/viz.json';
+      var vizJSON = 'https://juanignaciosl-ded03.carto-staging.com/api/v3/viz/7f4f7178-655e-11e6-bdcd-040146752f01/viz.json';
       cartodb.deepInsights.createDashboard('#dashboard', vizJSON, {
-        no_cdn: false
+        no_cdn: false,
+        autoStyle: true,
+        share_urls: true
       }, function(err, dashboard) {
-         var map = dashboard.getMap();
-         var params = {
-            "title": "Custom category",
-            "column": "adm0_a3",
-            "aggregationColumn": "adm0_a3",
-            "aggregation": "count",
-        };
+         // var map = dashboard.getMap();
+        //  var params = {
+        //     "title": "Custom category",
+        //     "column": "customer_value",
+        //     "aggregationColumn": "customer_value",
+        //     "aggregation": "count",
+        // };
         // adds a category using column `test` from the second layer
-        dashboard.createCategoryWidget(params, map.getLayer(1));
+        // dashboard.createCategoryWidget(params, map.getLayer(1));
         
-        setTimeout(function() {
-          // add a histogram and a formula
-          params = {
-              "title": "Custom histogram",
-              "type": "histogram",
-              "column": "pop_min",
-              "operation": "avg",
-              "bins": 15
-          }
-          dashboard.createHistogramWidget(params, map.getLayer(1));
-        }, 2000);
-        setTimeout(function() {
-          params = {
-              "title": "Custom formula",
-              "column": "cartodb_id",
-              "operation": "count"
-          }
-          dashboard.createFormulaWidget(params, map.getLayer(1));
-        }, 5000);
+        // setTimeout(function() {
+        //   // add a histogram and a formula
+        //   params = {
+        //       "title": "Custom histogram",
+        //       "type": "histogram",
+        //       "column": "customer_value",
+        //       "operation": "avg",
+        //       "bins": 3
+        //   }
+        //   dashboard.createHistogramWidget(params, map.getLayer(1));
+        // }, 2000);
+        // setTimeout(function() {
+        //   params = {
+        //       "title": "Custom formula",
+        //       "column": "cartodb_id",
+        //       "operation": "count"
+        //   }
+        //   dashboard.createFormulaWidget(params, map.getLayer(1));
+        // }, 5000);
       });
     }
   </script>

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "cartocolor": "4.0.0",
     "cartodb.js": "CartoDB/cartodb.js#v4",
     "d3": "3.5.17",
+    "d3-interpolate": "1.1.2",
     "jquery": "2.1.4",
     "moment": "2.10.6",
     "perfect-scrollbar": "0.6.7",

--- a/spec/widgets/histogram/chart.spec.js
+++ b/spec/widgets/histogram/chart.spec.js
@@ -582,6 +582,40 @@ describe('widgets/histogram/chart', function () {
           ]);
           expect(this.view._calculateDataDomain()).toEqual([2.1, 12]);
         });
+
+        it('should return 0, 0 when lo and hi bar indexes are NaN', function () {
+          spyOn(this.view, '_getLoBarIndex').and.returnValue(NaN);
+          spyOn(this.view, '_getHiBarIndex').and.returnValue(NaN);
+
+          this.applyNewData([
+            {
+              min: 0,
+              max: 2,
+              freq: 0
+            },
+            {
+              min: 2.1,
+              max: 4,
+              freq: 0
+            },
+            {
+              min: 4.1,
+              max: 6,
+              freq: 0
+            },
+            {
+              min: 6.1,
+              max: 8,
+              freq: 0
+            },
+            {
+              min: 8.1,
+              max: 12,
+              freq: 0
+            }
+          ]);
+          expect(this.view._calculateDataDomain()).toEqual([0, 0]);
+        });
       });
     });
   });

--- a/spec/widgets/histogram/chart.spec.js
+++ b/spec/widgets/histogram/chart.spec.js
@@ -102,32 +102,9 @@ describe('widgets/histogram/chart', function () {
     expect(this.view.$el.attr('style')).toMatch('none');
   });
 
-  describe('_setupFillColor', function () {
-    it('should setup the fill color initially', function () {
-      expect(WidgetHistogramChart.prototype._setupFillColor).toHaveBeenCalled();
-      expect(this.view._autoStyleColorsScale).not.toBeUndefined();
-    });
-
-    it('should not set autoStyleColorsScale function if auto-style is disabled', function () {
-      spyOn(this.widgetModel, 'isAutoStyleEnabled').and.returnValue(false);
-
-      var view = new WidgetHistogramChart(({
-        el: $('.js-chart'),
-        margin: this.margin,
-        chartBarColor: '#9DE0AD',
-        hasHandles: true,
-        height: 100,
-        data: this.data,
-        originalData: this.originalModel,
-        displayShadowBars: true,
-        widgetModel: this.widgetModel,
-        xAxisTickFormat: function (d, i) {
-          return d;
-        }
-      }));
-
-      expect(view._autoStyleColorsScale).toBeUndefined();
-    });
+  it('should setup the fill color initially', function () {
+    expect(WidgetHistogramChart.prototype._setupFillColor).toHaveBeenCalled();
+    expect(this.view._autoStyleColorsScale).toBeUndefined();
   });
 
   describe('normalize', function () {
@@ -341,7 +318,7 @@ describe('widgets/histogram/chart', function () {
       expect(this.view.$('.CDB-Chart-bar').attr('fill')).toEqual('red');
     });
 
-    it('should be colored by autostyle range colors when autostyle is applied', function () {
+    it('should be colored by linear gradients when autostyle is applied', function () {
       spyOn(this.widgetModel, 'isAutoStyle').and.returnValue(true);
       this.widgetModel.set({
         style: {
@@ -358,22 +335,9 @@ describe('widgets/histogram/chart', function () {
         }
       });
 
-      this.view.$('.CDB-Chart-bar').each(function (i, el) {
-        expect($(el).attr('fill')).not.toEqual('#9DE0AD');
-      });
-
       var dataSize = this.view.model.get('data').length;
       _.times(dataSize, function (i) {
-        var color;
-        if (i < 6) {
-          color = 'red';
-        } else if (i > 5 && i < 13) {
-          color = 'blue';
-        } else {
-          color = 'green';
-        }
-
-        expect(this.view.$('.CDB-Chart-bar:eq(' + i + ')').attr('fill')).toEqual(color);
+        expect(this.view.$('.CDB-Chart-bar:eq(' + i + ')').attr('fill')).toContain('url(#bar-');
       }, this);
     });
   });

--- a/spec/widgets/histogram/chart.spec.js
+++ b/spec/widgets/histogram/chart.spec.js
@@ -65,17 +65,10 @@ describe('widgets/histogram/chart', function () {
       }
     });
 
-    this.widgetModel.getWidgetColor = function () {
-      return '';
-    };
-
-    this.widgetModel.getAutoStyle = function () {
-      return this.attributes.style.auto_style;
-    };
-
-    this.widgetModel.isAutoStyle = function () {
-      return false;
-    };
+    this.widgetModel.getWidgetColor = function () { return ''; };
+    this.widgetModel.getAutoStyle = function () { return this.attributes.style.auto_style; };
+    this.widgetModel.isAutoStyleEnabled = function () { return true; };
+    this.widgetModel.isAutoStyle = function () { return false; };
 
     spyOn(WidgetHistogramChart.prototype, '_refreshBarsColor').and.callThrough();
     spyOn(WidgetHistogramChart.prototype, '_setupFillColor').and.callThrough();
@@ -109,8 +102,32 @@ describe('widgets/histogram/chart', function () {
     expect(this.view.$el.attr('style')).toMatch('none');
   });
 
-  it('should setup the fill color initially', function () {
-    expect(WidgetHistogramChart.prototype._setupFillColor).toHaveBeenCalled();
+  describe('_setupFillColor', function () {
+    it('should setup the fill color initially', function () {
+      expect(WidgetHistogramChart.prototype._setupFillColor).toHaveBeenCalled();
+      expect(this.view._autoStyleColorsScale).not.toBeUndefined();
+    });
+
+    it('should not set autoStyleColorsScale function if auto-style is disabled', function () {
+      spyOn(this.widgetModel, 'isAutoStyleEnabled').and.returnValue(false);
+
+      var view = new WidgetHistogramChart(({
+        el: $('.js-chart'),
+        margin: this.margin,
+        chartBarColor: '#9DE0AD',
+        hasHandles: true,
+        height: 100,
+        data: this.data,
+        originalData: this.originalModel,
+        displayShadowBars: true,
+        widgetModel: this.widgetModel,
+        xAxisTickFormat: function (d, i) {
+          return d;
+        }
+      }));
+
+      expect(view._autoStyleColorsScale).toBeUndefined();
+    });
   });
 
   describe('normalize', function () {

--- a/spec/widgets/histogram/chart.spec.js
+++ b/spec/widgets/histogram/chart.spec.js
@@ -77,6 +77,9 @@ describe('widgets/histogram/chart', function () {
       return false;
     };
 
+    spyOn(WidgetHistogramChart.prototype, '_refreshBarsColor').and.callThrough();
+    spyOn(WidgetHistogramChart.prototype, '_setupFillColor').and.callThrough();
+
     this.view = new WidgetHistogramChart(({
       el: $('.js-chart'),
       margin: this.margin,
@@ -104,6 +107,10 @@ describe('widgets/histogram/chart', function () {
 
   it('should be hidden initially', function () {
     expect(this.view.$el.attr('style')).toMatch('none');
+  });
+
+  it('should setup the fill color initially', function () {
+    expect(WidgetHistogramChart.prototype._setupFillColor).toHaveBeenCalled();
   });
 
   describe('normalize', function () {
@@ -277,6 +284,32 @@ describe('widgets/histogram/chart', function () {
       var data = this.view._getDataForScales();
       expect(data).not.toBe(this.originalData);
       expect(data).toBe(this.data);
+    });
+  });
+
+  describe('autostyle changes', function () {
+    beforeEach(function () {
+      this.widgetModel.set('autoStyle', true);
+    });
+
+    it('should trigger a refresh of the bars fill color', function () {
+      expect(WidgetHistogramChart.prototype._refreshBarsColor).toHaveBeenCalled();
+    });
+  });
+
+  describe('style changes', function () {
+    beforeEach(function () {
+      WidgetHistogramChart.prototype._setupFillColor.calls.reset();
+      WidgetHistogramChart.prototype._refreshBarsColor.calls.reset();
+      this.widgetModel.set('style', {});
+    });
+
+    it('should trigger a refresh of the bars fill color', function () {
+      expect(WidgetHistogramChart.prototype._refreshBarsColor.calls.count()).toEqual(1);
+    });
+
+    it('should setup the colors scale', function () {
+      expect(WidgetHistogramChart.prototype._setupFillColor.calls.count()).toEqual(1);
     });
   });
 

--- a/spec/widgets/histogram/content-view.spec.js
+++ b/spec/widgets/histogram/content-view.spec.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var specHelper = require('../../spec-helper');
 var HistogramContentView = require('../../../src/widgets/histogram/content-view');
 var HistogramWidgetModel = require('../../../src/widgets/histogram/histogram-widget-model');
+var HistogramChartView = require('../../../src/widgets/histogram/chart');
 
 describe('widgets/histogram/content-view', function () {
   beforeEach(function () {
@@ -13,7 +14,7 @@ describe('widgets/histogram/content-view', function () {
 
     this.originalData = this.dataviewModel._unfilteredData;
     this.originalData.set({
-      data: [{ bin: 10 }, { bin: 3 }],
+      data: [{ bin: 10, max: 0 }, { bin: 3, max: 10 }],
       start: 0,
       end: 256,
       bins: 2
@@ -36,6 +37,8 @@ describe('widgets/histogram/content-view', function () {
 
     spyOn(this.dataviewModel, 'getData').and.returnValue(['0', '1']);
     spyOn(this.dataviewModel, 'fetch').and.callThrough();
+
+    spyOn(HistogramChartView.prototype, '_setupFillColor').and.returnValue('red');
 
     this.view = new HistogramContentView({
       model: this.widgetModel,

--- a/spec/widgets/time-series/content-view.spec.js
+++ b/spec/widgets/time-series/content-view.spec.js
@@ -1,6 +1,7 @@
 var specHelper = require('../../spec-helper');
 var TimeSeriesContentView = require('../../../src/widgets/time-series/content-view');
 var WidgetModel = require('../../../src/widgets/widget-model');
+var HistogramChartView = require('../../../src/widgets/histogram/chart');
 
 describe('widgets/time-series/content-view', function () {
   beforeEach(function () {
@@ -22,6 +23,8 @@ describe('widgets/time-series/content-view', function () {
     var widgetModel = new WidgetModel({}, {
       dataviewModel: this.dataviewModel
     });
+
+    spyOn(HistogramChartView.prototype, '_setupFillColor').and.returnValue('red');
 
     spyOn(this.dataviewModel, 'fetch').and.callThrough();
     this.view = new TimeSeriesContentView({

--- a/spec/widgets/time-series/torque-content-view.spec.js
+++ b/spec/widgets/time-series/torque-content-view.spec.js
@@ -1,6 +1,7 @@
 var specHelper = require('../../spec-helper');
 var TorqueTimesSeriesContentView = require('../../../src/widgets/time-series/torque-content-view');
 var WidgetModel = require('../../../src/widgets/widget-model');
+var HistogramChartView = require('../../../src/widgets/histogram/chart');
 var cdb = require('cartodb.js');
 
 describe('widgets/time-series/torque-content-view', function () {
@@ -26,6 +27,9 @@ describe('widgets/time-series/torque-content-view', function () {
     var widgetModel = new WidgetModel({}, {
       dataviewModel: this.dataviewModel
     });
+
+    spyOn(HistogramChartView.prototype, '_setupFillColor').and.returnValue('red');
+
     this.view = new TorqueTimesSeriesContentView({
       model: widgetModel
     });
@@ -43,7 +47,7 @@ describe('widgets/time-series/torque-content-view', function () {
       var startTime = (new Date()).getTime() - timeOffset;
       this.dataviewModel.fetch();
       this.options.success({
-        bins: [{
+        data: [{
           start: startTime,
           end: startTime + timeOffset,
           freq: 3

--- a/spec/widgets/time-series/torque-time-slider-view.spec.js
+++ b/spec/widgets/time-series/torque-time-slider-view.spec.js
@@ -30,6 +30,9 @@ describe('widgets/time-series/torque-time-slider-view', function () {
       bottom: 3,
       left: 4
     };
+
+    spyOn(HistogramChartView.prototype, '_setupFillColor').and.returnValue('red');
+
     this.chartView = new HistogramChartView({
       margin: this.histogramChartMargins,
       height: 200,

--- a/spec/widgets/widget-model.spec.js
+++ b/spec/widgets/widget-model.spec.js
@@ -171,6 +171,15 @@ describe('widgets/widget-model', function () {
         this.model.set('style', style);
         expect(this.model.isAutoStyleEnabled()).toBe(false);
       });
+
+      it('should be false if type is not category or histogram', function () {
+        var model = new WidgetModel(null, {
+          dataviewModel: this.dataviewModel,
+          type: 'time-series'
+        }, {autoStyleEnabled: true});
+
+        expect(model.isAutoStyleEnabled()).toBeFalsy();
+      });
     });
   });
 

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -1031,7 +1031,7 @@ module.exports = cdb.core.View.extend({
   // in order to generate the proper colors ramp. It will depend
   // of the domain of the selected data.
   _generateFillGradients: function () {
-    if (!this._widgetModel.isAutoStyleEnabled()) {
+    if (!this._widgetModel || !this._widgetModel.isAutoStyleEnabled()) {
       return false;
     }
 

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -965,11 +965,18 @@ module.exports = cdb.core.View.extend({
   },
 
   _calculateDataDomain: function () {
-    var data = this.model.get('data');
-    var dataSize = data.length;
+    var data = _.clone(this.model.get('data'));
 
     if (!this._hasFilterApplied()) {
-      return [(data[0].min || data[0].start), (data[dataSize - 1].max || data[dataSize - 1].end)];
+      var minBucket = _.find(data, function (d) {
+        return d.freq !== 0;
+      });
+
+      var maxBucket = _.find(data.reverse(), function (d) {
+        return d.freq !== 0;
+      });
+
+      return [(minBucket.min || minBucket.start), (maxBucket.max || maxBucket.end)];
     } else {
       var extent = this.brush.extent();
       var loExtent = extent[0];
@@ -1008,8 +1015,6 @@ module.exports = cdb.core.View.extend({
     var domainScale = d3.scale.linear().domain(domain).range([0, 1]);
     var defs = d3.select(this.el).append('defs');
     var stopsNumber = 4;  // It is not necessary to create as many stops as colors
-
-    console.log(domain);
 
     var linearGradients = defs
       .selectAll('linearGradient')

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -974,6 +974,8 @@ module.exports = cdb.core.View.extend({
     return data[binIndex].max != null ? data[binIndex].max : data[binIndex].end;
   },
 
+  // Calculates the domain ([ min, max ]) of the selected data. If there is no selection ongoing,
+  // it will take the first and last buckets with frequency.
   _calculateDataDomain: function () {
     var data = _.clone(this.model.get('data'));
     var minBin;
@@ -1042,7 +1044,6 @@ module.exports = cdb.core.View.extend({
     var self = this;
     var geometryDefinition = obj.definition[Object.keys(obj.definition)[0]]; // Gets first definition by geometry
     var colorsRange = geometryDefinition && geometryDefinition.color.range;
-
     var data = this.model.get('data');
     var interpolatedColors = d3Interpolate.interpolateRgbBasis(colorsRange);
     var domain = this._calculateDataDomain();

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -999,16 +999,20 @@ module.exports = cdb.core.View.extend({
       var hiBarIndex = this._getHiBarIndex() - 1;
       var filteredData = data.slice(loBarIndex, hiBarIndex);
 
+      if (_.isNaN(loBarIndex) || _.isNaN(hiBarIndex)) {
+        return [0, 0];
+      }
+
       minValue = this._getMinValueFromBinIndex(loBarIndex);
       maxValue = this._getMaxValueFromBinIndex(hiBarIndex);
 
-      if (data[loBarIndex].freq === 0) {
+      if (data[loBarIndex] && data[loBarIndex].freq === 0) {
         minBin = _.find(filteredData, function (d) {
           return d.freq !== 0;
         }, this);
       }
 
-      if (data[hiBarIndex].freq === 0) {
+      if (data[hiBarIndex] && data[hiBarIndex].freq === 0) {
         var reversedData = filteredData.reverse();
         maxBin = _.find(reversedData, function (d) {
           return d.freq !== 0;

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -1264,7 +1264,6 @@ module.exports = cdb.core.View.extend({
       .enter()
       .append('rect')
       .attr('class', 'CDB-Chart-shadowBar')
-      // .attr('data', function (d) { return _.isEmpty(d) ? 0 : d.freq; })
       .attr('transform', function (d, i) {
         return 'translate(' + (i * barWidth) + ', 0 )';
       })

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -952,19 +952,21 @@ module.exports = cdb.core.View.extend({
 
   _setupFillColor: function () {
     var obj = this._widgetModel.getAutoStyle();
+    var data = this.model.get('data');
+
     if (!_.isEmpty(obj)) {
       for (var firstGeom in obj.definition) break;
       var colorsRange = obj && obj.definition[firstGeom].color.range;
 
-      this._autoStyleRangeColors = d3.scale.linear()
-        .domain([0, _.size(this.model.get('data'))])
+      this._autoStyleRangeColors = d3.scale.quantize()
+        .domain([_.first(data).min, _.last(data).max])
         .range(colorsRange);
     }
   },
 
   _getFillColor: function (d, i) {
     if (this._widgetModel.isAutoStyle()) {
-      return this._autoStyleRangeColors(i);
+      return this._autoStyleRangeColors(d.max);
     } else {
       return this._widgetModel.getWidgetColor() || this.options.chartBarColor;
     }
@@ -986,7 +988,9 @@ module.exports = cdb.core.View.extend({
       .append('rect')
       .attr('class', 'CDB-Chart-bar')
       .attr('fill', this._getFillColor.bind(this))
-      .attr('data', function (d) { return _.isEmpty(d) ? 0 : d.freq; })
+      .attr('data', function (d) {
+        return _.isEmpty(d) ? 0 : d.max;
+      })
       .attr('transform', function (d, i) {
         return 'translate(' + (i * self.barWidth) + ', 0 )';
       })
@@ -1059,7 +1063,9 @@ module.exports = cdb.core.View.extend({
       .append('rect')
       .attr('class', 'CDB-Chart-bar')
       .attr('fill', this._getFillColor.bind(self))
-      .attr('data', function (d) { return _.isEmpty(d) ? 0 : d.freq; })
+      .attr('data', function (d) {
+        return _.isEmpty(d) ? 0 : d.max;
+      })
       .attr('transform', function (d, i) {
         return 'translate(' + (i * self.barWidth) + ', 0 )';
       })

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -1072,10 +1072,6 @@ module.exports = cdb.core.View.extend({
     this._generateFillGradients();
   },
 
-  _hasFilterApplied: function () {
-    return this.model.get('lo_index') != null && this.model.get('hi_index') != null;
-  },
-
   _getFillColor: function (d, i) {
     if (this._widgetModel) {
       if (this._widgetModel.isAutoStyle()) {
@@ -1302,6 +1298,10 @@ module.exports = cdb.core.View.extend({
     // We need to explicitly move the lines of the grid behind the shadow bars
     this.chart.selectAll('.CDB-Chart-shadowBars').moveToBack();
     this.chart.selectAll('.CDB-Chart-lines').moveToBack();
+  },
+
+  _hasFilterApplied: function () {
+    return this.model.get('lo_index') != null && this.model.get('hi_index') != null;
   },
 
   unsetBounds: function () {

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -163,6 +163,8 @@ module.exports = cdb.core.View.extend({
     } else {
       this.refresh();
     }
+
+    this._setupFillColor();
   },
 
   _onChangeRange: function () {
@@ -282,7 +284,7 @@ module.exports = cdb.core.View.extend({
 
     bars
       .classed('is-highlighted', false)
-      // .attr('fill', this._getFillColor.bind(this));
+      .attr('fill', this._getFillColor.bind(this));
     this.trigger('hover', { value: null });
   },
 
@@ -995,8 +997,6 @@ module.exports = cdb.core.View.extend({
     var domainScale = d3.scale.linear().domain(domain).range([0, 1]);
     var defs = d3.select(this.el).append('defs');
 
-    console.log('selected ' + domain);
-
     var linearGradients = defs
       .selectAll('linearGradient')
       .data(data)
@@ -1063,7 +1063,15 @@ module.exports = cdb.core.View.extend({
   },
 
   _getHoverFillColor: function (d, i) {
-    return this._getFillColor(d, i); // 'url(#bar-' + i + ')'; // tinycolor(this._getFillColor(d, i)).darken(20).toString();
+    var currentFillColor = this._getFillColor(d, i);
+
+    if (this._widgetModel) {
+      if (this._widgetModel.isAutoStyle()) {
+        return currentFillColor;
+      }
+    }
+
+    return tinycolor(currentFillColor).darken(20).toString();
   },
 
   _updateChart: function () {
@@ -1078,10 +1086,6 @@ module.exports = cdb.core.View.extend({
       .append('rect')
       .attr('class', 'CDB-Chart-bar')
       .attr('fill', this._getFillColor.bind(this))
-      // .attr('data', function (d) {
-      //   var maxValue = d.max || d.end;
-      //   return _.isEmpty(d) ? 0 : maxValue;
-      // })
       .attr('transform', function (d, i) {
         return 'translate(' + (i * self.barWidth) + ', 0 )';
       })
@@ -1154,20 +1158,13 @@ module.exports = cdb.core.View.extend({
       .append('rect')
       .attr('class', 'CDB-Chart-bar')
       .attr('fill', this._getFillColor.bind(self))
-      // .attr('data', function (d) {
-      //   var maxValue = d.max || d.end;
-      //   return _.isEmpty(d) ? 0 : maxValue;
-      // })
-      .attr('fill', function (d, i) {
-        return 'url(#bar-0)';
-      })
       .attr('transform', function (d, i) {
         return 'translate(' + (i * self.barWidth) + ', 0 )';
       })
       .attr('y', self.chartHeight())
       .attr('height', 0)
-      .attr('width', Math.max(0.5, this.barWidth - 1))
-      
+      .attr('width', Math.max(0.5, this.barWidth - 1));
+
     bars
       .transition()
       .ease(this.options.transitionType)

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -971,11 +971,15 @@ module.exports = cdb.core.View.extend({
   },
 
   _getFillColor: function (d, i) {
-    if (this._widgetModel.isAutoStyle()) {
-      return this._autoStyleColorsScale(d.max);
-    } else {
-      return this._widgetModel.getWidgetColor() || this.options.chartBarColor;
+    if (this._widgetModel) {
+      if (this._widgetModel.isAutoStyle()) {
+        return this._autoStyleColorsScale(d.max);
+      } else {
+        return this._widgetModel.getWidgetColor() || this.options.chartBarColor;
+      }
     }
+
+    return this.options.chartBarColor;
   },
 
   _getHoverFillColor: function (d, i) {

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -951,6 +951,10 @@ module.exports = cdb.core.View.extend({
   },
 
   _setupFillColor: function () {
+    if (!this._widgetModel.isAutoStyleEnabled()) {
+      return false;
+    }
+
     var obj = this._widgetModel.getAutoStyle();
     var data = this.model.get('data');
 

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -57,9 +57,6 @@ module.exports = cdb.core.View.extend({
       .append('g')
       .attr('class', 'CDB-WidgetCanvas');
 
-    // this.canvas
-    //   .append('defs');
-
     this._setupModel();
     this._setupBindings();
     this._setupDimensions();
@@ -165,6 +162,7 @@ module.exports = cdb.core.View.extend({
     }
 
     this._setupFillColor();
+    this._refreshBarsColor();
   },
 
   _onChangeRange: function () {
@@ -989,8 +987,10 @@ module.exports = cdb.core.View.extend({
       return false;
     }
 
+    var self = this;
     var geometryDefinition = obj.definition[Object.keys(obj.definition)[0]]; // Gets first definition by geometry
     var colorsRange = geometryDefinition && geometryDefinition.color.range;
+
     var data = this.model.get('data');
     var interpolatedColors = d3Interpolate.interpolateRgbBasis(colorsRange);
     var domain = this._calculateDataDomain();
@@ -1004,7 +1004,7 @@ module.exports = cdb.core.View.extend({
       .append('linearGradient')
       .attr('id', function (d, i) {
         this.__scale__ = d3.scale.linear().range([ d.start, d.end ]).domain([0, 1]);
-        return 'bar-' + i;
+        return 'bar-' + self.cid + '-' + i;
       })
       .attr('x1', '0%')
       .attr('y1', '0%')
@@ -1017,7 +1017,7 @@ module.exports = cdb.core.View.extend({
       .enter()
       .append('stop')
       .attr('offset', function (d, i) {
-        var offset = this.__offset__ = ((i + 1) / colorsRange.length) * 100;
+        var offset = this.__offset__ = Math.floor(((i + 1) / colorsRange.length) * 100);
         return (offset + '%');
       })
       .attr('stop-color', function (d, i) {
@@ -1045,7 +1045,7 @@ module.exports = cdb.core.View.extend({
           }
         }
 
-        return 'url(#bar-' + i + ')';
+        return 'url(#bar-' + this.cid + '-' + i + ')';
       } else {
         if (this._hasFilterApplied()) {
           if (this._isBarChartWithinFilter(i)) {

--- a/src/widgets/time-series/torque-histogram-view.js
+++ b/src/widgets/time-series/torque-histogram-view.js
@@ -49,13 +49,15 @@ module.exports = cdb.core.View.extend({
 
   _createHistogramView: function () {
     var chartType = this._torqueLayerModel.get('column_type') === 'date' ? 'time' : 'number';
+    var widgetModel = this._parent.model;
+
     this._chartView = new HistogramChartView({
       type: chartType,
       animationSpeed: 100,
       animationBarDelay: function (d, i) {
         return (i * 3);
       },
-      chartBarColor: this._parent.model.getWidgetColor() || '#F2CC8F',
+      chartBarColor: widgetModel.getWidgetColor() || '#F2CC8F',
       margin: {
         top: 4,
         right: 4,
@@ -66,6 +68,7 @@ module.exports = cdb.core.View.extend({
       height: this.defaults.histogramChartHeight,
       data: this._dataviewModel.getData(),
       originalData: this._originalData,
+      widgetModel: widgetModel,
       displayShadowBars: true
     });
 

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -125,7 +125,7 @@ module.exports = cdb.core.Model.extend({
     this.set('autoStyle', false);
   },
 
-  getAutoStyle: function getAutoStyle () {
+  getAutoStyle: function () {
     var style = this.get('style');
     var cartocss = this.dataviewModel.layer.get('cartocss');
 

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -73,10 +73,7 @@ module.exports = cdb.core.Model.extend({
     var styles = this.get('style');
 
     if (this.get('type') === 'category' || this.get('type') === 'histogram') {
-      if (!styles || !styles.auto_style) {
-        return true;
-      }
-      return styles && styles.auto_style && styles.auto_style.allowed;
+      return (styles && styles.auto_style && styles.auto_style.allowed) || true;
     } else {
       return false;
     }

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -94,7 +94,7 @@ module.exports = cdb.core.Model.extend({
   },
 
   isAutoStyle: function () {
-    return this.get('autoStyle');
+    return !!this.get('autoStyle');
   },
 
   autoStyle: function () {

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -72,8 +72,14 @@ module.exports = cdb.core.Model.extend({
 
     var styles = this.get('style');
 
-    if ((!styles || !styles.auto_style) && (this.get('type') === 'category' || this.get('type') === 'histogram')) return true;
-    return styles && styles.auto_style && styles.auto_style.allowed;
+    if (this.get('type') === 'category' || this.get('type') === 'histogram') {
+      if (!styles || !styles.auto_style) {
+        return true;
+      }
+      return styles && styles.auto_style && styles.auto_style.allowed;
+    } else {
+      return false;
+    }
   },
 
   getWidgetColor: function () {
@@ -127,7 +133,8 @@ module.exports = cdb.core.Model.extend({
 
   getAutoStyle: function () {
     var style = this.get('style');
-    var cartocss = this.dataviewModel.layer.get('cartocss');
+    var layerModel = this.dataviewModel.layer;
+    var cartocss = layerModel.get('cartocss') || (layerModel.get('meta') && layerModel.get('meta').cartocss);
 
     if (style && style.auto_style && style.auto_style.definition) {
       var toRet = _.extend(style.auto_style, {cartocss: cartocss});

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -76,7 +76,7 @@ module.exports = cdb.core.Model.extend({
       if (!styles || !styles.auto_style) {
         return true;
       }
-      
+
       return styles && styles.auto_style && styles.auto_style.allowed;
     } else {
       return false;

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -73,7 +73,11 @@ module.exports = cdb.core.Model.extend({
     var styles = this.get('style');
 
     if (this.get('type') === 'category' || this.get('type') === 'histogram') {
-      return (styles && styles.auto_style && styles.auto_style.allowed) || true;
+      if (!styles || !styles.auto_style) {
+        return true;
+      }
+      
+      return styles && styles.auto_style && styles.auto_style.allowed;
     } else {
       return false;
     }

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -94,7 +94,7 @@ module.exports = cdb.core.Model.extend({
   },
 
   isAutoStyle: function () {
-    return !!this.get('autoStyle');
+    return this.get('autoStyle');
   },
 
   autoStyle: function () {

--- a/themes/scss/widgets/themes/light.scss
+++ b/themes/scss/widgets/themes/light.scss
@@ -208,12 +208,6 @@ $chartMiniSelected: rgba(#333, 1);
   .CDB-Chart-bar--timeSeries.is-highlighted {
     fill: $darkHighlightedAlternative;
   }
-  .CDB-Chart-bar.is-selected {
-    fill: $selected;
-  }
-  .CDB-Chart-bar.is-filtered {
-    fill: $lightHighlight;
-  }
   .CDB-Chart-shadowBar {
     fill: $lightHighlight;
   }


### PR DESCRIPTION
It represents the colors applied with the auto style in the histogram bars.
Related ticket:  https://github.com/CartoDB/cartodb/issues/11095.

![screen shot 2017-01-04 at 15 21 05](https://cloud.githubusercontent.com/assets/132146/21645398/20aa796e-d292-11e6-98be-48243e75dd2a.png)
![screen shot 2017-01-04 at 15 24 08](https://cloud.githubusercontent.com/assets/132146/21645400/20b1c606-d292-11e6-80db-b81089ee040f.png)
<img width="639" alt="screen shot 2017-01-04 at 15 25 10" src="https://cloud.githubusercontent.com/assets/132146/21645399/20b10234-d292-11e6-8c4a-61c74fb719b9.png">


**What should you test?**
Having an account with auto-style flag enabled:

- Applying the autostyle over a **histogram widget** should represent the same colors in the histogram bars.
- Disabling autostyle should remove the autostyle colors over the bars.
- Having applied the autostyle, change the number of bins/buckets of the widget and look if the widget is refreshed with the new bins and with the autostyle colors applied over the bars.
- Disable the autostyle and check that bars are back to the default color.
- Apply the autostyle over a histogram widget, check if the colors are ok and then move the map in order to change the widget bars height, color should keep the same.
- Add another histogram widget over the same "layer", and apply autostyle over that new widget. Autostyle colors should be there, ok. Then apply the autostyle for the previous widget in order to disable the autostyle. Newest widget should reset its bars color.
- Check if you change the widget fill color and the histogram is refreshed with that color over the bars.
- Check if you change the widget autostyle colors and they have been represented in the widget bars.
- Add a time-series widget.
- Test all previous changes in the public embed.
- **Last one, but not less important, disable autostyle flag and check that your map and widgets keep working as they should**.

**Available in ded03.**