### PR TITLE
Don't update auto-style colors when the feauture is disabled

### DIFF
--- a/spec/widgets/category/category-widget-model.spec.js
+++ b/spec/widgets/category/category-widget-model.spec.js
@@ -12,6 +12,9 @@ describe('widgets/category/category-widget-model', function () {
     this.dataviewModel = vis.dataviews.createCategoryModel(layer, {
       column: 'col'
     });
+
+    spyOn(CategoryWidgetModel.prototype, '_updateColors').and.callThrough();
+
     this.widgetModel = new CategoryWidgetModel({}, {
       dataviewModel: this.dataviewModel
     }, {autoStyleEnabled: true});
@@ -42,6 +45,15 @@ describe('widgets/category/category-widget-model', function () {
       this.dataviewModel.layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
       spyOn(this.widgetModel.autoStyler.colors, 'updateData').and.callThrough();
       spyOn(this.widgetModel, 'autoStyle').and.callThrough();
+    });
+
+    it('should not update colors if auto style is not enabled', function () {
+      var widgetModel = new CategoryWidgetModel({}, {
+        dataviewModel: this.dataviewModel
+      }, { autoStyleEnabled: false });
+
+      widgetModel.set('style', 'whatever');
+      expect(CategoryWidgetModel.prototype._updateColors).not.toHaveBeenCalled();
     });
 
     describe('when category names are updated', function () {

--- a/src/widgets/category/category-widget-model.js
+++ b/src/widgets/category/category-widget-model.js
@@ -28,9 +28,14 @@ module.exports = WidgetModel.extend({
     this.lockedCategories = new LockedCategoriesCollection();
 
     this.listenTo(this.dataviewModel, 'change:allCategoryNames', this._onDataviewAllCategoryNamesChange);
+
     this.on('change:locked', this._onLockedChange, this);
     this.on('change:collapsed', this._onCollapsedChange, this);
-    this.on('change:style', this._updateColors, this);
+
+    if (this.isAutoStyleEnabled()) {
+      this.on('change:style', this._updateColors, this);
+    }
+
     this.dataviewModel.filter.on('change', function () {
       this.set('acceptedCategories', this._acceptedCategories().pluck('name'));
     }, this);


### PR DESCRIPTION
This problem is related with https://github.com/CartoDB/cartodb/issues/11166. We can't update auto-style colors when the feature is disabled. That throws an error and makes the app fail.

**STT**
- Basically the same steps described in https://github.com/CartoDB/cartodb/issues/11166.

Uploading to ded02 in order to be tested.