### PR TITLE
Show options in a dashboard with a small screen

### DIFF
--- a/themes/scss/widgets/default.scss
+++ b/themes/scss/widgets/default.scss
@@ -138,7 +138,8 @@
     max-width: 190px;
     padding-right: 12px;
   }
-  .CDB-Widget-actions {
+  
+  .CDB-Widget-body .js-toggleCollapsed {
     display: none;
   }
 }


### PR DESCRIPTION
Related with https://github.com/CartoDB/cartodb/pull/11122/.

<img width="415" alt="screen shot 2017-01-05 at 12 17 17" src="https://cloud.githubusercontent.com/assets/132146/21679174/da990bc8-d342-11e6-8c93-36ac3d208290.png">