### PR TITLE
11246 issue

### DIFF
--- a/spec/widgets/auto-style/category.spec.js
+++ b/spec/widgets/auto-style/category.spec.js
@@ -9,7 +9,7 @@ describe('src/widgets/auto-style/category', function () {
     var layer = vis.map.layers.first();
     this.dataview = new Backbone.Model({
       data: [
-        { name: 'soccer' },
+        { name: "soccer" },
         { name: 'basketball' },
         { name: 'baseball' },
         { name: 'handball' },
@@ -32,31 +32,31 @@ describe('src/widgets/auto-style/category', function () {
   describe('.getStyle', function () {
     it('should generate the right styles when layer has polygons', function () {
       this.dataview.layer.set('initialStyle', '#layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1;  polygon-fill: #e49115;  polygon-fill-opacity: 0.9; }');
-      expect(this.categoryAutoStyler.getStyle()).toBe(" #layer ['mapnik::geometry_type'=3] { polygon-fill: ramp([something], ('#7F3C8D', '#11A579', '#3969AC', '#F2B701', '#E73F74'), ('soccer', 'basketball', 'baseball', 'handball', 'hockey'));  }  #layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1;   polygon-fill-opacity: 0.9; }");
+      expect(this.categoryAutoStyler.getStyle()).toBe(' #layer [\'mapnik::geometry_type\'=3] { polygon-fill: ramp([something], ("#7F3C8D", "#11A579", "#3969AC", "#F2B701", "#E73F74"), ("soccer", "basketball", "baseball", "handball", "hockey"));  }  #layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1;   polygon-fill-opacity: 0.9; }');
     });
 
     it('should generate the right styles when layer has points', function () {
       this.layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
-      expect(this.categoryAutoStyler.getStyle()).toBe("  #layer ['mapnik::geometry_type'=1] { marker-fill: ramp([something], ('#7F3C8D', '#11A579', '#3969AC', '#F2B701', '#E73F74'), ('soccer', 'basketball', 'baseball', 'handball', 'hockey'));  } #layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;   marker-fill-opacity: 0.9;  marker-allow-overlap: true;}");
+      expect(this.categoryAutoStyler.getStyle()).toBe('  #layer [\'mapnik::geometry_type\'=1] { marker-fill: ramp([something], ("#7F3C8D", "#11A579", "#3969AC", "#F2B701", "#E73F74"), ("soccer", "basketball", "baseball", "handball", "hockey"));  } #layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;   marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
     });
 
     it('should generate the right styles when layer has lines', function () {
       this.dataview.layer.set('initialStyle', '#layer {  line-width: 0.5;  line-color: #fcfafa;  line-opacity: 1; }');
-      expect(this.categoryAutoStyler.getStyle()).toBe("#layer ['mapnik::geometry_type'=2] { line-color: ramp([something], ('#7F3C8D', '#11A579', '#3969AC', '#F2B701', '#E73F74'), ('soccer', 'basketball', 'baseball', 'handball', 'hockey'));  }   #layer {  line-width: 0.5;   line-opacity: 1; }");
+      expect(this.categoryAutoStyler.getStyle()).toBe('#layer [\'mapnik::geometry_type\'=2] { line-color: ramp([something], ("#7F3C8D", "#11A579", "#3969AC", "#F2B701", "#E73F74"), ("soccer", "basketball", "baseball", "handball", "hockey"));  }   #layer {  line-width: 0.5;   line-opacity: 1; }');
     });
 
     it('should generate unique attr style when layer has multiple attrs', function () {
       this.dataview.layer.set('initialStyle', '#layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1;  polygon-fill: #e49115;  polygon-fill-opacity: 0.9; [random > 0.5] { polygon-fill: #adadad; } }');
-      expect(this.categoryAutoStyler.getStyle()).toBe(" #layer ['mapnik::geometry_type'=3] { polygon-fill: ramp([something], ('#7F3C8D', '#11A579', '#3969AC', '#F2B701', '#E73F74'), ('soccer', 'basketball', 'baseball', 'handball', 'hockey'));  }  #layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1;   polygon-fill-opacity: 0.9; }");
+      expect(this.categoryAutoStyler.getStyle()).toBe(' #layer [\'mapnik::geometry_type\'=3] { polygon-fill: ramp([something], ("#7F3C8D", "#11A579", "#3969AC", "#F2B701", "#E73F74"), ("soccer", "basketball", "baseball", "handball", "hockey"));  }  #layer {  polygon-line-width: 0.5;  polygon-line-color: #fcfafa;  polygon-line-opacity: 1;   polygon-fill-opacity: 0.9; }');
     });
 
-    it('should escape single quotes correctly', function () {
+    it('should escape double quotes correctly', function () {
       var data = this.dataview.get('data');
-      data.push({ name: "Oh'Yeah" }); // eslint-disable-line
+      data.push({ name: 'Oh"Yeah' });
       this.dataview.set('data', data);
       this.layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
       this.updateColorsByData();
-      expect(this.categoryAutoStyler.getStyle()).toBe("  #layer ['mapnik::geometry_type'=1] { marker-fill: ramp([something], ('#7F3C8D', '#11A579', '#3969AC', '#F2B701', '#E73F74', '#A5AA99'), ('soccer', 'basketball', 'baseball', 'handball', 'hockey', 'Oh\\'Yeah'));  } #layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;   marker-fill-opacity: 0.9;  marker-allow-overlap: true;}");
+      expect(this.categoryAutoStyler.getStyle()).toBe('  #layer [\'mapnik::geometry_type\'=1] { marker-fill: ramp([something], ("#7F3C8D", "#11A579", "#3969AC", "#F2B701", "#E73F74", "#A5AA99"), ("soccer", "basketball", "baseball", "handball", "hockey", "Oh\\"Yeah"));  } #layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;   marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
     });
 
     it('should generate proper CartoCSS when Others is included', function () {
@@ -65,7 +65,7 @@ describe('src/widgets/auto-style/category', function () {
       this.dataview.set('data', data);
       this.layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
       this.updateColorsByData();
-      expect(this.categoryAutoStyler.getStyle()).toBe("  #layer ['mapnik::geometry_type'=1] { marker-fill: ramp([something], ('#7F3C8D', '#11A579', '#3969AC', '#F2B701', '#E73F74', '#A5AA99'), ('soccer', 'basketball', 'baseball', 'handball', 'hockey'));  } #layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;   marker-fill-opacity: 0.9;  marker-allow-overlap: true;}");
+      expect(this.categoryAutoStyler.getStyle()).toBe('  #layer [\'mapnik::geometry_type\'=1] { marker-fill: ramp([something], ("#7F3C8D", "#11A579", "#3969AC", "#F2B701", "#E73F74", "#A5AA99"), ("soccer", "basketball", "baseball", "handball", "hockey"));  } #layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;   marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
     });
   });
 });

--- a/spec/widgets/auto-style/category.spec.js
+++ b/spec/widgets/auto-style/category.spec.js
@@ -9,7 +9,7 @@ describe('src/widgets/auto-style/category', function () {
     var layer = vis.map.layers.first();
     this.dataview = new Backbone.Model({
       data: [
-        { name: "soccer" },
+        { name: 'soccer' },
         { name: 'basketball' },
         { name: 'baseball' },
         { name: 'handball' },

--- a/spec/widgets/auto-style/category.spec.js
+++ b/spec/widgets/auto-style/category.spec.js
@@ -59,6 +59,15 @@ describe('src/widgets/auto-style/category', function () {
       expect(this.categoryAutoStyler.getStyle()).toBe('  #layer [\'mapnik::geometry_type\'=1] { marker-fill: ramp([something], ("#7F3C8D", "#11A579", "#3969AC", "#F2B701", "#E73F74", "#A5AA99"), ("soccer", "basketball", "baseball", "handball", "hockey", "Oh\\"Yeah"));  } #layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;   marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
     });
 
+    it('should not escape single quotes', function () {
+      var data = this.dataview.get('data');
+      data.push({ name: "Oh'Yeah" });
+      this.dataview.set('data', data);
+      this.layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
+      this.updateColorsByData();
+      expect(this.categoryAutoStyler.getStyle()).toBe('  #layer [\'mapnik::geometry_type\'=1] { marker-fill: ramp([something], ("#7F3C8D", "#11A579", "#3969AC", "#F2B701", "#E73F74", "#A5AA99"), ("soccer", "basketball", "baseball", "handball", "hockey", "Oh\'Yeah"));  } #layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;   marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
+    });
+
     it('should generate proper CartoCSS when Others is included', function () {
       var data = this.dataview.get('data');
       data.push({ name: 'Others', agg: true });

--- a/src/widgets/auto-style/category.js
+++ b/src/widgets/auto-style/category.js
@@ -54,13 +54,13 @@ module.exports = AutoStyler.extend({
 
     for (var i = 0; i < categories.length; i++) {
       var cat = categories[i];
-      var start = "'";
-      var end = i !== categories.length - 1 ? "', " : "'";
+      var start = '"';
+      var end = i !== categories.length - 1 ? '", ' : '"';
 
       catListColors += start + this.colors.getColorByCategory(cat.name) + end;
       if (!cat.agg) {
-        catListValues += start + cat.name.replace(/'/g, '\\\'') + end;
-      } else if (end === "'") {
+        catListValues += start + cat.name.replace(/"/g, '\\"') + end;
+      } else if (end === '"') {
         catListValues = catListValues.substring(0, catListValues.length - 2);
       }
     }


### PR DESCRIPTION
Ticket: cartodb/cartodb#11246.

Changing way to escape quotes with auto-style, following the same way we use within Builder and categories.

**Things to test:**
Check the ticket, because there is a good example there, but in any case:
- Create a map with a layer where the data contains single and double quotes.
- Add a category widget using the column where those single and double quotes are present.
- Autostyle that widget.
