### PR TITLE
Don't offer auto-style if it is not possible to auto-style due to a custom cartocss with image

### DIFF
--- a/spec/widgets/category/search-title-view.spec.js
+++ b/spec/widgets/category/search-title-view.spec.js
@@ -23,6 +23,7 @@ describe('widgets/category/search-title-view', function () {
       this.widgetModel = new CategoryWidgetModel({}, {
         dataviewModel: this.dataviewModel
       }, {autoStyleEnabled: true});
+
       this.view = new SearchTitleView({
         widgetModel: this.widgetModel,
         dataviewModel: this.dataviewModel
@@ -35,7 +36,6 @@ describe('widgets/category/search-title-view', function () {
       expect($el.find('.js-title').length).toBe(1);
       expect($el.find('.CDB-Widget-options').length).toBe(1);
       expect($el.find('.js-titleText').length).toBe(1);
-      expect(this.view.$('.js-autoStyle').length).toBe(1);
     });
 
     describe('search', function () {
@@ -87,6 +87,7 @@ describe('widgets/category/search-title-view', function () {
 
     describe('options', function () {
       beforeEach(function () {
+        spyOn(this.view, '_isAutoStyleButtonVisible').and.returnValue(true);
         this.view.render();
       });
 
@@ -108,24 +109,70 @@ describe('widgets/category/search-title-view', function () {
       });
     });
 
-    describe('allowed', function () {
+    describe('autostyle', function () {
       beforeEach(function () {
-        this.view.render();
+        this.dataviewModel.layer.set('cartocss', '#whatever {}');
       });
 
-      it('should remove button when not allowed', function () {
-        this.widgetModel.set('style', {auto_style: {allowed: false}});
-        expect(this.view.$('.js-autoStyle').length).toBe(0);
+      describe('checking allowed', function () {
+        beforeEach(function () {
+          spyOn(this.view.model, 'getAutoStyle').and.returnValue({
+            cartocss: '#whatever {}',
+            definition: 'dummy'
+          });
+          this.view.render();
+        });
+
+        it('should remove button when not allowed', function () {
+          this.widgetModel.set('style', {auto_style: {allowed: false}});
+          expect(this.view.$('.js-autoStyle').length).toBe(0);
+        });
+
+        it('should show button when allowed', function () {
+          this.widgetModel.set('style', {auto_style: {allowed: true}});
+          expect(this.view.$('.js-autoStyle').length).toBe(1);
+        });
       });
 
-      it('should show button when allowed', function () {
-        this.widgetModel.set('style', {auto_style: {allowed: true}});
-        expect(this.view.$('.js-autoStyle').length).toBe(1);
+      describe('checking layer visibility', function () {
+        beforeEach(function () {
+          spyOn(this.view.model, 'getAutoStyle').and.returnValue({
+            cartocss: '#whatever {}',
+            definition: 'dummy'
+          });
+          this.view.render();
+        });
+
+        it('should not render the autostyle button if layer is hidden', function () {
+          layer.set({visible: false});
+          expect(this.view.$('.js-autoStyle').length).toBe(0);
+        });
       });
 
-      it('should not render the autostyle button if layer is hidden', function () {
-        layer.set({visible: false});
-        expect(this.view.$('.js-autoStyle').length).toBe(0);
+      describe('checking auto-style definition', function () {
+        it('should display autostyle button if definition exists', function () {
+          spyOn(this.view.model, 'getAutoStyle').and.returnValue({
+            cartocss: '#whatever {}',
+            definition: {
+              point: {
+                fill: {
+                  color: 'red'
+                }
+              }
+            }
+          });
+          this.view.render();
+          expect(this.view.$('.js-autoStyle').length).toBe(1);
+        });
+
+        it('should not display autostyle button if definition doesn\'t exist', function () {
+          spyOn(this.view.model, 'getAutoStyle').and.returnValue({
+            cartocss: '#whatever {}',
+            definition: {}
+          });
+          this.view.render();
+          expect(this.view.$('.js-autoStyle').length).toBe(0);
+        });
       });
     });
   });

--- a/spec/widgets/category/search-title-view.spec.js
+++ b/spec/widgets/category/search-title-view.spec.js
@@ -116,10 +116,7 @@ describe('widgets/category/search-title-view', function () {
 
       describe('checking allowed', function () {
         beforeEach(function () {
-          spyOn(this.view.model, 'getAutoStyle').and.returnValue({
-            cartocss: '#whatever {}',
-            definition: 'dummy'
-          });
+          spyOn(this.view.model, 'hasColorsAutoStyle').and.returnValue(true);
           this.view.render();
         });
 
@@ -136,10 +133,7 @@ describe('widgets/category/search-title-view', function () {
 
       describe('checking layer visibility', function () {
         beforeEach(function () {
-          spyOn(this.view.model, 'getAutoStyle').and.returnValue({
-            cartocss: '#whatever {}',
-            definition: 'dummy'
-          });
+          spyOn(this.view.model, 'hasColorsAutoStyle').and.returnValue(true);
           this.view.render();
         });
 
@@ -151,25 +145,13 @@ describe('widgets/category/search-title-view', function () {
 
       describe('checking auto-style definition', function () {
         it('should display autostyle button if definition exists', function () {
-          spyOn(this.view.model, 'getAutoStyle').and.returnValue({
-            cartocss: '#whatever {}',
-            definition: {
-              point: {
-                fill: {
-                  color: 'red'
-                }
-              }
-            }
-          });
+          spyOn(this.view.model, 'hasColorsAutoStyle').and.returnValue(true);
           this.view.render();
           expect(this.view.$('.js-autoStyle').length).toBe(1);
         });
 
         it('should not display autostyle button if definition doesn\'t exist', function () {
-          spyOn(this.view.model, 'getAutoStyle').and.returnValue({
-            cartocss: '#whatever {}',
-            definition: {}
-          });
+          spyOn(this.view.model, 'hasColorsAutoStyle').and.returnValue(false);
           this.view.render();
           expect(this.view.$('.js-autoStyle').length).toBe(0);
         });
@@ -183,16 +165,7 @@ describe('widgets/category/search-title-view', function () {
         dataviewModel: this.dataviewModel
       }, {autoStyleEnabled: false});
 
-      spyOn(widgetModel, 'getAutoStyle').and.returnValue({
-        cartocss: '#whatever {}',
-        definition: {
-          point: {
-            fill: {
-              color: 'red'
-            }
-          }
-        }
-      });
+      spyOn(widgetModel, 'hasColorsAutoStyle').and.returnValue(true);
 
       this.view = new SearchTitleView({
         widgetModel: widgetModel,

--- a/spec/widgets/histogram/chart.spec.js
+++ b/spec/widgets/histogram/chart.spec.js
@@ -674,6 +674,12 @@ describe('widgets/histogram/chart', function () {
       this.view.el = document.createElement('svg'); // Hack it!
     });
 
+    it('should not generate any gradient if auto-style colors are not provided', function () {
+      this.view._widgetModel.getAutoStyle.and.returnValue({});
+      this.view._generateFillGradients();
+      expect(this.getLinearGradients().length).toBe(0);
+    });
+
     it('should generate as many gradients as data we have', function () {
       this.view._generateFillGradients();
       expect(this.getLinearGradients()[0].length).toBe(5);

--- a/spec/widgets/histogram/chart.spec.js
+++ b/spec/widgets/histogram/chart.spec.js
@@ -73,6 +73,9 @@ describe('widgets/histogram/chart', function () {
     spyOn(WidgetHistogramChart.prototype, '_refreshBarsColor').and.callThrough();
     spyOn(WidgetHistogramChart.prototype, '_setupFillColor').and.callThrough();
 
+    this.dataviewModel = new cdb.core.Model();
+    this.dataviewModel.layer = new cdb.core.Model();
+
     this.view = new WidgetHistogramChart(({
       el: $('.js-chart'),
       margin: this.margin,
@@ -80,6 +83,7 @@ describe('widgets/histogram/chart', function () {
       hasHandles: true,
       height: 100,
       data: this.data,
+      dataviewModel: this.dataviewModel,
       originalData: this.originalModel,
       displayShadowBars: true,
       widgetModel: this.widgetModel,
@@ -783,6 +787,22 @@ describe('widgets/histogram/chart', function () {
           expect(stopsInLastGradient[0][3].getAttribute('stop-color')).not.toBe(this.yellowColor);
         });
       });
+    });
+  });
+
+  describe('on dataview layer cartocss change', function () {
+    it('should generate bar gradients if they were not defined before', function () {
+      this.view._setupFillColor.calls.reset();
+      spyOn(this.view, '_areGradientsAlreadyGenerated').and.returnValue(false);
+      this.dataviewModel.layer.set('cartocss', '#dummy {}');
+      expect(this.view._setupFillColor.calls.count()).toBe(1);
+    });
+
+    it('should not generate bar gradients if they were defined before', function () {
+      this.view._setupFillColor.calls.reset();
+      spyOn(this.view, '_areGradientsAlreadyGenerated').and.returnValue(true);
+      this.dataviewModel.layer.set('cartocss', '#dummy {}');
+      expect(this.view._setupFillColor.calls.count()).toBe(0);
     });
   });
 

--- a/spec/widgets/histogram/histogram-title-view.spec.js
+++ b/spec/widgets/histogram/histogram-title-view.spec.js
@@ -76,11 +76,7 @@ describe('widgets/histogram/title-view', function () {
 
       describe('checking allowed', function () {
         beforeEach(function () {
-          spyOn(this.widgetModel, 'getAutoStyle').and.returnValue({
-            cartocss: '#whatever {}',
-            definition: 'dummy'
-          });
-
+          spyOn(this.widgetModel, 'hasColorsAutoStyle').and.returnValue(true);
           this.view.render();
         });
 
@@ -112,25 +108,13 @@ describe('widgets/histogram/title-view', function () {
 
       describe('checking auto-style definition', function () {
         it('should display autostyle button if definition exists', function () {
-          spyOn(this.widgetModel, 'getAutoStyle').and.returnValue({
-            cartocss: '#whatever {}',
-            definition: {
-              point: {
-                fill: {
-                  color: 'red'
-                }
-              }
-            }
-          });
+          spyOn(this.widgetModel, 'hasColorsAutoStyle').and.returnValue(true);
           this.view.render();
           expect(this.view.$('.js-autoStyle').length).toBe(1);
         });
 
         it('should not display autostyle button if definition doesn\'t exist', function () {
-          spyOn(this.widgetModel, 'getAutoStyle').and.returnValue({
-            cartocss: '#whatever {}',
-            definition: {}
-          });
+          spyOn(this.widgetModel, 'hasColorsAutoStyle').and.returnValue(false);
           this.view.render();
           expect(this.view.$('.js-autoStyle').length).toBe(0);
         });

--- a/spec/widgets/widget-model.spec.js
+++ b/spec/widgets/widget-model.spec.js
@@ -189,6 +189,87 @@ describe('widgets/widget-model', function () {
         expect(model.isAutoStyleEnabled()).toBeFalsy();
       });
     });
+
+    describe('.hasColorsAutoStyle', function () {
+      it('should return false if autostyle or auto-style definition is empty', function () {
+        spyOn(this.model, 'getAutoStyle').and.returnValue({
+          cartocss: '#dummy {}',
+          definition: {}
+        });
+        expect(this.model.hasColorsAutoStyle()).toBe(false);
+        this.model.getAutoStyle.and.returnValue({});
+        expect(this.model.hasColorsAutoStyle()).toBe(false);
+      });
+
+      it('should return false if color or range doesn\'t exist', function () {
+        spyOn(this.model, 'getAutoStyle').and.returnValue({
+          cartocss: '#dummy {}',
+          definition: {
+            point: {}
+          }
+        });
+        expect(this.model.hasColorsAutoStyle()).toBe(false);
+        this.model.getAutoStyle.and.returnValue({
+          cartocss: '#dummy {}',
+          definition: {
+            point: {
+              color: {}
+            }
+          }
+        });
+        expect(this.model.hasColorsAutoStyle()).toBe(false);
+      });
+
+      it('should return false if there is no colors defined', function () {
+        spyOn(this.model, 'getAutoStyle').and.returnValue({
+          cartocss: '#dummy {}',
+          definition: {
+            point: {
+              color: {
+                range: []
+              }
+            }
+          }
+        });
+        expect(this.model.hasColorsAutoStyle()).toBe(false);
+
+        this.model.getAutoStyle.and.returnValue({
+          cartocss: '#dummy {}',
+          definition: {
+            point: {
+              color: {
+                range: {}
+              }
+            },
+            line: {
+              color: {
+                range: {}
+              }
+            },
+            polygon: {
+              color: {
+                range: {}
+              }
+            }
+          }
+        });
+        expect(this.model.hasColorsAutoStyle()).toBe(false);
+      });
+
+      it('should return true if autostyle return any color', function () {
+        spyOn(this.model, 'getAutoStyle').and.returnValue({
+          cartocss: '#dummy {}',
+          definition: {
+            point: {
+              color: {
+                range: ['#red']
+              }
+            }
+          }
+        });
+        expect(this.model.hasColorsAutoStyle()).toBe(true);
+      });
+    });
   });
 
   describe('when autostyle option is disabled', function () {

--- a/src/widgets/auto-style/histogram.js
+++ b/src/widgets/auto-style/histogram.js
@@ -57,16 +57,19 @@ var HistogramAutoStyler = AutoStyler.extend({
         var scales = HistogramAutoStyler.SCALES_MAP[item][shape];
         var geom = item.substring(0, item.indexOf('-'));
         var definition = {};
-        if (isCustomDefinition === true) {
-          definition = _.extend(definition, styles.definition);
-        } else {
-          definition = {
-            color: {
-              range: cartocolor[scales.palette][bins] || cartocolor[scales.palette][Object.keys(cartocolor[scales.palette]).length],
-              quantification: scales.quantification,
-              attribute: attr
-            }
-          };
+
+        if (scales) {
+          if (isCustomDefinition === true) {
+            definition = _.extend(definition, styles.definition);
+          } else {
+            definition = {
+              color: {
+                range: cartocolor[scales.palette][bins] || cartocolor[scales.palette][Object.keys(cartocolor[scales.palette]).length],
+                quantification: scales.quantification,
+                attribute: attr
+              }
+            };
+          }
         }
 
         definitions[geom === 'marker' ? 'point' : geom] = definition;

--- a/src/widgets/category/category-widget-model.js
+++ b/src/widgets/category/category-widget-model.js
@@ -87,6 +87,24 @@ module.exports = WidgetModel.extend({
     }
   },
 
+  hasAutoStyleColors: function () {
+    var autoStyle = this.getAutoStyle();
+    var hasDefinedColors = false;
+
+    if (!autoStyle || _.isEmpty(autoStyle) || _.isEmpty(autoStyle.definition)) {
+      return false;
+    }
+
+    // Check colors by geometry
+    _.each(autoStyle.definition, function (geometryStyle) {
+      if (geometryStyle.color && geometryStyle.color.range && geometryStyle.color.range.length > 0) {
+        hasDefinedColors = true;
+      }
+    }, this);
+
+    return hasDefinedColors;
+  },
+
   isLocked: function () {
     return this.get('locked');
   },

--- a/src/widgets/category/category-widget-model.js
+++ b/src/widgets/category/category-widget-model.js
@@ -87,24 +87,6 @@ module.exports = WidgetModel.extend({
     }
   },
 
-  hasAutoStyleColors: function () {
-    var autoStyle = this.getAutoStyle();
-    var hasDefinedColors = false;
-
-    if (!autoStyle || _.isEmpty(autoStyle) || _.isEmpty(autoStyle.definition)) {
-      return false;
-    }
-
-    // Check colors by geometry
-    _.each(autoStyle.definition, function (geometryStyle) {
-      if (geometryStyle.color && geometryStyle.color.range && geometryStyle.color.range.length > 0) {
-        hasDefinedColors = true;
-      }
-    }, this);
-
-    return hasDefinedColors;
-  },
-
   isLocked: function () {
     return this.get('locked');
   },

--- a/src/widgets/category/title/search-title-view.js
+++ b/src/widgets/category/title/search-title-view.js
@@ -49,9 +49,13 @@ module.exports = cdb.core.View.extend({
 
   _initBinds: function () {
     this.model.bind('change:search', this._onSearchToggled, this);
-    this.model.bind('change:title change:collapsed change:autoStyle change:style change:data', this.render, this);
+    this.model.bind('change:title change:collapsed change:autoStyle change:style', this.render, this);
     this.model.lockedCategories.bind('change add remove', this.render, this);
     this.add_related_model(this.model.lockedCategories);
+
+    this.dataviewModel.bind('change:data', this.render, this);
+    this.add_related_model(this.dataviewModel);
+
     this.dataviewModel.filter.bind('change', this.render, this);
     this.add_related_model(this.dataviewModel.filter);
 

--- a/src/widgets/category/title/search-title-view.js
+++ b/src/widgets/category/title/search-title-view.js
@@ -49,7 +49,7 @@ module.exports = cdb.core.View.extend({
 
   _initBinds: function () {
     this.model.bind('change:search', this._onSearchToggled, this);
-    this.model.bind('change:title change:collapsed change:autoStyle change:style', this.render, this);
+    this.model.bind('change:title change:collapsed change:autoStyle change:style change:data', this.render, this);
     this.model.lockedCategories.bind('change add remove', this.render, this);
     this.add_related_model(this.model.lockedCategories);
     this.dataviewModel.filter.bind('change', this.render, this);

--- a/src/widgets/category/title/search-title-view.js
+++ b/src/widgets/category/title/search-title-view.js
@@ -76,13 +76,9 @@ module.exports = cdb.core.View.extend({
   },
 
   _isAutoStyleButtonVisible: function () {
-    var layerModelMeta = this.dataviewModel.layer.get('meta');
-    var cartocss = this.dataviewModel.layer.get('cartocss') || (layerModelMeta && layerModelMeta.cartocss);
-    var autoStyle = cartocss && this.model.getAutoStyle();
-
     return this.model.isAutoStyleEnabled() &&
       this.dataviewModel.layer.get('visible') &&
-      (autoStyle && !_.isEmpty(autoStyle.definition));
+      this.model.hasAutoStyleColors();
   },
 
   _onSearchToggled: function () {

--- a/src/widgets/category/title/search-title-view.js
+++ b/src/widgets/category/title/search-title-view.js
@@ -28,12 +28,11 @@ module.exports = cdb.core.View.extend({
   },
 
   render: function () {
-    var isAutoStyleButtonVisible = this.model.isAutoStyleEnabled() && this.dataviewModel.layer.get('visible');
     this.clearSubViews();
     this.$el.html(
       template({
         isCollapsed: this.model.get('collapsed'),
-        isAutoStyleEnabled: isAutoStyleButtonVisible,
+        isAutoStyleEnabled: this._isAutoStyleButtonVisible(),
         isAutoStyle: this.model.isAutoStyle(),
         title: this.model.get('title'),
         columnName: this.dataviewModel.get('column'),
@@ -56,8 +55,8 @@ module.exports = cdb.core.View.extend({
     this.dataviewModel.filter.bind('change', this.render, this);
     this.add_related_model(this.dataviewModel.filter);
 
-    this.dataviewModel.layer.bind('change:visible', this.render, this);
-    this.add_related_model(this.dataviewModel);
+    this.dataviewModel.layer.bind('change:visible change:cartocss', this.render, this);
+    this.add_related_model(this.dataviewModel.layer);
   },
 
   _initViews: function () {
@@ -74,6 +73,16 @@ module.exports = cdb.core.View.extend({
     });
     $('body').append(colorsTooltip.render().el);
     this.addView(colorsTooltip);
+  },
+
+  _isAutoStyleButtonVisible: function () {
+    var layerModelMeta = this.dataviewModel.layer.get('meta');
+    var cartocss = this.dataviewModel.layer.get('cartocss') || (layerModelMeta && layerModelMeta.cartocss);
+    var autoStyle = cartocss && this.model.getAutoStyle();
+
+    return this.model.isAutoStyleEnabled() &&
+      this.dataviewModel.layer.get('visible') &&
+      (autoStyle && !_.isEmpty(autoStyle.definition));
   },
 
   _onSearchToggled: function () {

--- a/src/widgets/category/title/search-title-view.js
+++ b/src/widgets/category/title/search-title-view.js
@@ -78,7 +78,7 @@ module.exports = cdb.core.View.extend({
   _isAutoStyleButtonVisible: function () {
     return this.model.isAutoStyleEnabled() &&
       this.dataviewModel.layer.get('visible') &&
-      this.model.hasAutoStyleColors();
+      this.model.hasColorsAutoStyle();
   },
 
   _onSearchToggled: function () {

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -1041,7 +1041,7 @@ module.exports = cdb.core.View.extend({
 
     var obj = this._widgetModel.getAutoStyle();
 
-    if (_.isEmpty(obj)) {
+    if (_.isEmpty(obj) || _.isEmpty(obj.definition)) {
       return false;
     }
 

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -48,6 +48,7 @@ module.exports = cdb.core.View.extend({
     this.setElement($('<svg class=""></svg>')[0]);
 
     this._widgetModel = this.options.widgetModel;
+    this._dataviewModel = this.options.dataviewModel;
 
     this.canvas = d3.select(this.el)
       .attr('width', 0)
@@ -498,6 +499,15 @@ module.exports = cdb.core.View.extend({
         this._refreshBarsColor();
       }, this);
       this.add_related_model(this._widgetModel);
+    }
+
+    if (this._dataviewModel) {
+      this._dataviewModel.layer.bind('change:cartocss', function () {
+        if (!this._areGradientsAlreadyGenerated()) {
+          this._setupFillColor();
+        }
+      }, this);
+      this.add_related_model(this._dataviewModel.layer);
     }
 
     if (this._originalData) {
@@ -1029,6 +1039,12 @@ module.exports = cdb.core.View.extend({
   _removeFillGradients: function () {
     var defs = d3.select(this.el).select('defs');
     defs.remove();
+  },
+
+  _areGradientsAlreadyGenerated: function () {
+    var defs = d3.select(this.el).append('defs');
+    var linearGradients = defs.selectAll('linearGradient');
+    return linearGradients[0].length > 0;
   },
 
   // Generate a linear-gradient with several stops for each bar

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -1039,12 +1039,11 @@ module.exports = cdb.core.View.extend({
   _removeFillGradients: function () {
     var defs = d3.select(this.el).select('defs');
     defs.remove();
+    delete this._linearGradients;
   },
 
   _areGradientsAlreadyGenerated: function () {
-    var defs = d3.select(this.el).append('defs');
-    var linearGradients = defs.selectAll('linearGradient');
-    return linearGradients[0].length > 0;
+    return !!this._linearGradients;
   },
 
   // Generate a linear-gradient with several stops for each bar
@@ -1071,7 +1070,7 @@ module.exports = cdb.core.View.extend({
     var defs = d3.select(this.el).append('defs');
     var stopsNumber = 4;  // It is not necessary to create as many stops as colors
 
-    var linearGradients = defs
+    this._linearGradients = defs
       .selectAll('linearGradient')
       .data(data)
       .enter()
@@ -1088,7 +1087,7 @@ module.exports = cdb.core.View.extend({
       .attr('x2', '100%')
       .attr('y2', '0%');
 
-    linearGradients
+    this._linearGradients
       .selectAll('stop')
       .data(d3.range(stopsNumber + 1))
       .enter()

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -264,6 +264,7 @@ module.exports = cdb.core.View.extend({
       width: this.canvasWidth,
       height: this.defaults.chartHeight,
       data: this._dataviewModel.getData(),
+      dataviewModel: this._dataviewModel,
       originalData: this._originalData,
       displayShadowBars: !this.model.get('normalized'),
       normalized: this.model.get('normalized'),

--- a/src/widgets/histogram/histogram-title-view.js
+++ b/src/widgets/histogram/histogram-title-view.js
@@ -20,7 +20,7 @@ module.exports = cdb.core.View.extend({
   initialize: function (opts) {
     if (!opts.widgetModel) throw new Error('widgetModel is needed');
     if (!opts.dataviewModel) throw new Error('dataviewModel is needed');
-    
+
     this.widgetModel = opts.widgetModel;
     this.dataviewModel = opts.dataviewModel;
     this._initBinds();

--- a/src/widgets/histogram/histogram-title-view.js
+++ b/src/widgets/histogram/histogram-title-view.js
@@ -17,9 +17,12 @@ module.exports = cdb.core.View.extend({
     'click .js-cancelAutoStyle': '_cancelAutoStyle'
   },
 
-  initialize: function () {
-    this.widgetModel = this.options.widgetModel;
-    this.dataviewModel = this.options.dataviewModel;
+  initialize: function (opts) {
+    if (!opts.widgetModel) throw new Error('widgetModel is needed');
+    if (!opts.dataviewModel) throw new Error('dataviewModel is needed');
+    
+    this.widgetModel = opts.widgetModel;
+    this.dataviewModel = opts.dataviewModel;
     this._initBinds();
   },
 

--- a/src/widgets/histogram/histogram-title-view.js
+++ b/src/widgets/histogram/histogram-title-view.js
@@ -60,11 +60,11 @@ module.exports = cdb.core.View.extend({
   _isAutoStyleButtonVisible: function () {
     var layerModelMeta = this.dataviewModel.layer.get('meta');
     var cartocss = this.dataviewModel.layer.get('cartocss') || (layerModelMeta && layerModelMeta.cartocss);
-    var autoStyle = cartocss && this.widgetModel.getAutoStyle();
+    var hasColorsAutoStyle = cartocss && this.widgetModel.hasColorsAutoStyle();
 
     return this.widgetModel.isAutoStyleEnabled() &&
       this.dataviewModel.layer.get('visible') &&
-      (autoStyle && !_.isEmpty(autoStyle.definition));
+      hasColorsAutoStyle;
   },
 
   _autoStyle: function () {

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -92,6 +92,24 @@ module.exports = cdb.core.Model.extend({
           styles.widget_style.definition.color.fixed;
   },
 
+  hasColorsAutoStyle: function () {
+    var autoStyle = this.getAutoStyle();
+    var hasDefinedColors = false;
+
+    if (!autoStyle || _.isEmpty(autoStyle) || _.isEmpty(autoStyle.definition)) {
+      return false;
+    }
+
+    // Check colors in all geometries
+    _.each(autoStyle.definition, function (geometryStyle) {
+      if (geometryStyle.color && geometryStyle.color.range && geometryStyle.color.range.length > 0) {
+        hasDefinedColors = true;
+      }
+    }, this);
+
+    return hasDefinedColors;
+  },
+
   getColor: function (name) {
     if (this.isAutoStyleEnabled() && this.isAutoStyle() && this.get('type') === 'category') {
       return this.autoStyler.colors.getColorByCategory(name);


### PR DESCRIPTION
Problem coming from: https://github.com/CartoDB/cartodb-management/issues/4815, and reproduced here https://github.com/CartoDB/deep-insights.js/issues/513.

**THINGS TO TEST**

- Apply a custom CartoCSS with icons (not common circles or anything), check that autostyle button disappears.
- Unapply custom CartoCSS, apply a standard one and check that autostyle button is back.
- Check that other combinations are not affected, like testing it with layer visibility, if it is allowed, etc.
- Check that, if a histogram widget is added when the cartocss doesn't provide any [marker-fill or polygon-fill or line-color], autostyle button doesn't appear. After that, reset the cartocss, provide a simple one, and autostyle button should appear again, click it and check that bars appear colored properly.
- Check time-series widget could be added correctly without problems.