### PR TITLE
change of classification method for F shape distribution

### DIFF
--- a/src/widgets/auto-style/histogram.js
+++ b/src/widgets/auto-style/histogram.js
@@ -82,7 +82,7 @@ HistogramAutoStyler.SCALES_MAP = {
   'polygon-fill': {
     'F': {
       palette: 'PinkYl',
-      quantification: 'quantiles'
+      quantification: 'equal'
     },
     'L': {
       palette: 'Emrld',
@@ -108,7 +108,7 @@ HistogramAutoStyler.SCALES_MAP = {
   'line-color': {
     'F': {
       palette: 'PinkYl',
-      quantification: 'quantiles'
+      quantification: 'equal'
     },
     'L': {
       palette: 'Emrld',
@@ -134,7 +134,7 @@ HistogramAutoStyler.SCALES_MAP = {
   'marker-fill': {
     'F': {
       palette: 'RedOr',
-      quantification: 'quantiles'
+      quantification: 'equal'
     },
     'L': {
       palette: 'BluYl',


### PR DESCRIPTION
This is a change to the classification method we use behind the scenes for the Histogram widget with a F shaped distribution. I had originally set it to quantiles but after more thought, equal is more appropriate.

Please let me know if you have any questions

cc @saleiva 