### PR TITLE
Fixed placeholder styles

### DIFF
--- a/src/widgets/category/list/items-view.js
+++ b/src/widgets/category/list/items-view.js
@@ -55,14 +55,14 @@ module.exports = cdb.core.View.extend({
   _renderPlaceholder: function () {
     // Change view classes
     this.$el
-      .addClass('CDB-Widget-list--withBorders')
+      .addClass('CDB-Widget-list--withBorders CDB-Widget-list--fake')
       .removeClass('CDB-Widget-list--wrapped');
     this.$el.append(placeholder());
   },
 
   _renderList: function () {
     // Change view classes
-    this.$el.removeClass('CDB-Widget-list--withBorders');
+    this.$el.removeClass('CDB-Widget-list--withBorders CDB-Widget-list--fake');
     this.$el[this.options.paginator ? 'addClass' : 'removeClass']('CDB-Widget-list--wrapped');
 
     var groupItem;

--- a/themes/scss/widgets/list.scss
+++ b/themes/scss/widgets/list.scss
@@ -77,6 +77,10 @@
   padding: 0 $baseSize * 3;
 }
 
+.CDB-Widget-list--fake {
+  flex-direction: column;
+}
+
 .CDB-Widget-list--wrapped .CDB-Widget-listGroup {
   overflow: visible;
 }
@@ -104,8 +108,8 @@
 }
 .CDB-Widget-listItem--fake {
   position: relative;
+  display: block;
   margin-top: $baseSize;
-  margin-bottom: 36px;
   border-bottom: 1px solid transparent;
 
   &:before,
@@ -117,7 +121,7 @@
     content: '';
   }
   &:before {
-    width: 60px;
+    width: 100%;
     height: $baseSize;
   }
   &:after {
@@ -125,11 +129,6 @@
     height: $baseSize / 4;
   }
 }
-/*
-.CDB-Widget-content .CDB-Widget-listItem--fake {
-  margin-right: 0;
-  margin-left: 0;
-}*/
 .CDB-Widget-listSubItem {
   display: inline-block;
 }
@@ -209,5 +208,13 @@
   .CDB-Widget-listItemInner {
     margin: 0;
     padding: 2px 8px;
+  }
+  .CDB-Widget-list--fake {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+  .CDB-Widget-content--noSidesMargin .CDB-Widget-listItem--fake {
+    margin-right: 12px;
+    margin-left: 12px;
   }
 }

--- a/themes/scss/widgets/list.scss
+++ b/themes/scss/widgets/list.scss
@@ -41,7 +41,6 @@
     bottom: 0;
   }
 }
-
 .CDB-Widget-list {
   @include display-flex();
   position: relative;


### PR DESCRIPTION
There is a problem right now with the category widget placeholder, it really gets me mad:

<img width="412" alt="screen shot 2017-01-27 at 18 12 26" src="https://cloud.githubusercontent.com/assets/132146/22380047/36c2a55a-e4bc-11e6-80f1-9ce8497e2e36.png">

So, when it is fixed:

- Desktop:
<img width="357" alt="screen shot 2017-01-27 at 18 10 46" src="https://cloud.githubusercontent.com/assets/132146/22380058/45cc155e-e4bc-11e6-9a26-079f20ec2251.png">
<img width="318" alt="screen shot 2017-01-27 at 18 10 49" src="https://cloud.githubusercontent.com/assets/132146/22380059/45f25e44-e4bc-11e6-9a01-765a57184d30.png">

- Mobile:
<img width="474" alt="screen shot 2017-01-27 at 18 07 26" src="https://cloud.githubusercontent.com/assets/132146/22380070/50632386-e4bc-11e6-82d9-c6466096def7.png">
<img width="221" alt="screen shot 2017-01-27 at 18 07 31" src="https://cloud.githubusercontent.com/assets/132146/22380071/50646d18-e4bc-11e6-9e80-5ea81e25f2bf.png">

