### PR TITLE
Fixes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   "dependencies": {
     "backbone": "1.2.3",
     "cartocolor": "4.0.0",
-    "cartodb.js": "CartoDB/cartodb.js#385-mobile-issues",
+    "cartodb.js": "CartoDB/cartodb.js#v4",
     "d3": "3.5.17",
     "d3-interpolate": "1.1.2",
     "jquery": "2.1.4",
     "moment": "2.10.6",
-    "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#touchmove",
+    "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
     "tinycolor2": "1.4.1",
     "underscore": "1.8.3",
     "urijs": "1.17.1"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "d3-interpolate": "1.1.2",
     "jquery": "2.1.4",
     "moment": "2.10.6",
-    "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
+    "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#touchmove",
     "tinycolor2": "1.4.1",
     "underscore": "1.8.3",
     "urijs": "1.17.1"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "backbone": "1.2.3",
     "cartocolor": "4.0.0",
-    "cartodb.js": "CartoDB/cartodb.js#v4",
+    "cartodb.js": "CartoDB/cartodb.js#385-mobile-issues",
     "d3": "3.5.17",
     "d3-interpolate": "1.1.2",
     "jquery": "2.1.4",

--- a/src/widgets/category/paginator/paginator-template.tpl
+++ b/src/widgets/category/paginator/paginator-template.tpl
@@ -1,3 +1,4 @@
+<% if (showSearch) { %>
 <div class="CDB-Widget-contentFlex">
   <button class="u-rSpace--m CDB-Text is-semibold u-upperCase CDB-Size-small js-searchToggle">
     <div class="CDB-Shape u-iBlock">
@@ -8,6 +9,7 @@
     </span>
   </button>
 </div>
+<% } %>
 <% if (showPaginator) { %>
   <div class="CDB-Widget-navDots js-dots">
     <% for (var i = 0, l = pages; i < l; i++) { %><button class="CDB-Shape-dot CDB-Widget-dot--navigation js-page <% if (currentPage === i) { %>is-selected<% } %>" data-page="<%- i %>"></button><% } %>

--- a/src/widgets/category/paginator/paginator-view.js
+++ b/src/widgets/category/paginator/paginator-view.js
@@ -37,12 +37,14 @@ module.exports = cdb.core.View.extend({
     this.clearSubViews();
     this.$el.empty();
     var categoriesCount = this.dataviewModel.getCount();
+    var isMobile = 'ontouchstart' in window;
 
     if (categoriesCount > MINCATEGORIES) {
       var pages = Math.ceil(this.dataviewModel.getSize() / this.options.itemsPerPage);
       var template = this.options.template;
       this.$el.html(
         template({
+          showSearch: !isMobile,
           showPaginator: this.options.paginator,
           currentPage: this.model.get('page'),
           categoriesCount: categoriesCount,

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -790,6 +790,7 @@ module.exports = cdb.core.View.extend({
       .attr('class', 'Brush')
       .call(this.brush)
       .selectAll('rect')
+      .attr('class', 'ps-prevent-touchmove')
       .attr('y', 0)
       .attr('height', this.chartHeight())
       .on('mouseout', this._onMouseOut)


### PR DESCRIPTION
This PR implements #385.

- It hides search button on mobile. Right now the search functionality is impossible to use in mobile because the keyboard resizes the viewport. Then all views are rendered again, and finally the keyboard hides.
- It adds proper class to let ps know it does not have to handle the `touchmove` event. This depends on https://github.com/CartoDB/perfect-scrollbar/pull/1.

Besides this PR and the one commented above, we need to update cartodb.js as well (there is already a branch for that). The order to merge should be: PS repo, cartodb.js and the last one, this PR.
