### PR TITLE
Removed unnecessary nice function from time-series header view

### DIFF
--- a/src/widgets/time-series/time-series-header-view.js
+++ b/src/widgets/time-series/time-series-header-view.js
@@ -82,12 +82,10 @@ module.exports = cdb.core.View.extend({
     if (columnType === 'date') {
       this._scale = d3.time.scale()
         .domain([data[0].start * 1000, data[data.length - 1].end * 1000])
-        .nice()
         .range([this._dataviewModel.get('start'), this._dataviewModel.get('end')]);
     } else {
       this._scale = d3.scale.linear()
         .domain([data[0].start, data[data.length - 1].end])
-        .nice()
         .range([this._dataviewModel.get('start'), this._dataviewModel.get('end')]);
     }
   },

--- a/src/widgets/time-series/torque-time-info-view.js
+++ b/src/widgets/time-series/torque-time-info-view.js
@@ -33,7 +33,6 @@ module.exports = cdb.core.View.extend({
     var template = columnType === 'number' ? numberTemplate : timeTemplate;
     var scale = d3.scale.linear()
       .domain([0, data.length])
-      .nice()
       .range([this._dataviewModel.get('start'), this._dataviewModel.get('end')]);
     var html = '';
 


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/cartodb/issues/11174

We were rounding (nicely) selection dates, and it was causing problems in the way we calculate selected ranges. 

An example with the same dataset, before and after:

Before:
![screen shot 2017-02-24 at 13 01 58](https://cloud.githubusercontent.com/assets/132146/23302961/895dda56-fa91-11e6-8de8-6bdb2c858e69.png)

After:
![screen shot 2017-02-24 at 13 02 21](https://cloud.githubusercontent.com/assets/132146/23302962/89606690-fa91-11e6-8483-67ff53925f52.png)

cc @michellechandra  @zingbot