### PR TITLE
Fixed problem with loader position in time-series widget

### DIFF
--- a/themes/scss/widgets/default.scss
+++ b/themes/scss/widgets/default.scss
@@ -2,6 +2,7 @@
 //
 // Expected layout hierarchy:
 //   CDB-Widget
+//     CDB-Loader
 //     CDB-Widget-error
 //     CDB-Widget-body
 //       CDB-Widget-header
@@ -17,6 +18,8 @@
   // Due to line-heights, better to substract some pixels in the top
   padding: ($sMargin-section - 4) 0;
   box-sizing: border-box;
+  overflow-x: hidden; // Not showing the loader in any side
+
   .CDB-Loader {
     height: 1px;
   }
@@ -129,7 +132,7 @@
     padding: 12px 0;
     border-left-width: 1px;
     border-left-style: solid;
-    overflow: hidden;
+
     .CDB-Loader {
       height: 2px;
     }


### PR DESCRIPTION
Related: https://github.com/CartoDB/cartodb/issues/11754

Basically that, right now the loader for the time-series widget is visible although the loader is inactive. With this change it should be 👌 . It is also applied for any widget, just in case. 
Checked that tooltips work properly.

