### PR TITLE
When dataBin is not defined it should not return anything

### DIFF
--- a/spec/widgets/histogram/chart.spec.js
+++ b/spec/widgets/histogram/chart.spec.js
@@ -298,6 +298,12 @@ describe('widgets/histogram/chart', function () {
 
           expect(this.view._calculateDataDomain()).toEqual([0, 6]);
         });
+
+        it('should return null when there is no data', function () {
+          this.applyNewData([]);
+
+          expect(this.view._calculateDataDomain()).toEqual([null, null]);
+        });
       });
 
       describe('not all bins with freq data', function () {
@@ -399,6 +405,12 @@ describe('widgets/histogram/chart', function () {
             }
           ]);
           expect(this.view._calculateDataDomain()).toEqual([2.1, 8]);
+        });
+
+        it('should return null when there is no data', function () {
+          this.applyNewData([]);
+
+          expect(this.view._calculateDataDomain()).toEqual([null, null]);
         });
       });
     });

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -977,12 +977,22 @@ module.exports = cdb.core.View.extend({
 
   _getMinValueFromBinIndex: function (binIndex) {
     var data = this.model.get('data');
-    return data[binIndex].min != null ? data[binIndex].min : data[binIndex].start;
+    var dataBin = data[binIndex];
+    if (dataBin) {
+      return dataBin.min != null ? dataBin.min : dataBin.start;
+    } else {
+      return null;
+    }
   },
 
   _getMaxValueFromBinIndex: function (binIndex) {
     var data = this.model.get('data');
-    return data[binIndex].max != null ? data[binIndex].max : data[binIndex].end;
+    var dataBin = data[binIndex];
+    if (dataBin) {
+      return dataBin.min != null ? dataBin.max : dataBin.end;
+    } else {
+      return null;
+    }
   },
 
   // Calculates the domain ([ min, max ]) of the selected data. If there is no selection ongoing,


### PR DESCRIPTION
Related ticket: https://github.com/CartoDB/cartodb/issues/11798

Steps to reproduce already described there ^^^. But good ones also are:

- Create a map with a histogram widget where the there is at least a bucket without data.
Example: 
![screen shot 2017-03-21 at 19 12 10](https://cloud.githubusercontent.com/assets/132146/24163299/6b76c09c-0e6a-11e7-88ba-5bde9f7a67f3.png)

- Select the bin or bins without data and zoom into it/them.
Example:
![screen shot 2017-03-21 at 19 12 15](https://cloud.githubusercontent.com/assets/132146/24163358/9f8ff0ce-0e6a-11e7-97cf-5a67993d9d42.png)
- JS error appeared, now zoomed histogram should be empty.
