### PR TITLE
Replace way to trigger widget state changes

### DIFF
--- a/spec/api/create-dashboard.spec.js
+++ b/spec/api/create-dashboard.spec.js
@@ -82,6 +82,7 @@ describe('create-dashboard', function () {
 
       expect(error).toBe(null);
       expect(dashboard instanceof APIDashboard).toBeTruthy();
+      expect(dashboard._dashboard.areWidgetsInitialised).toBeDefined();
     });
 
     it('should return an API dashboard object and error if there was an error', function () {
@@ -99,6 +100,7 @@ describe('create-dashboard', function () {
 
       expect(error).not.toBe(null);
       expect(dashboard instanceof APIDashboard).toBeTruthy();
+      expect(dashboard._dashboard.areWidgetsInitialised).toBeDefined();
     });
 
     it('should skip map instantiation and explictely isntantiate the map after everything has been loaded', function () {
@@ -112,6 +114,46 @@ describe('create-dashboard', function () {
       this.visMock.trigger('load', this.visMock);
 
       expect(this.visMock.instantiateMap).toHaveBeenCalled();
+    });
+
+    describe('areWidgetsInitialised', function () {
+      beforeEach(function () {
+        var callback = jasmine.createSpy('callback');
+        createDashboard(this.selectorId, this.vizJSON, {}, callback);
+        this.visMock.trigger('load', this.visMock);
+        this.visMock.instantiateMap.calls.argsFor(0)[0].success();
+        this.dashboard = callback.calls.argsFor(0)[1];
+
+        this.widgetsCollection = this.dashboard._dashboard.widgets._widgetsCollection;
+        spyOn(this.widgetsCollection, 'hasInitialState');
+        spyOn(this.widgetsCollection, 'size');
+      });
+
+      describe('if there are widgets', function () {
+        beforeEach(function () {
+          this.widgetsCollection.size.and.returnValue(2);
+        });
+
+        it('should return false when widgets don\'t have initial state', function () {
+          this.widgetsCollection.hasInitialState.and.returnValue(false);
+          expect(this.dashboard._dashboard.areWidgetsInitialised()).toBeFalsy();
+        });
+
+        it('should return true when widgets have initial state', function () {
+          this.widgetsCollection.hasInitialState.and.returnValue(true);
+          expect(this.dashboard._dashboard.areWidgetsInitialised()).toBeTruthy();
+        });
+      });
+
+      describe('if there is no widgets', function () {
+        beforeEach(function () {
+          this.widgetsCollection.size.and.returnValue(0);
+        });
+
+        it('should return true when there are no widgets', function () {
+          expect(this.dashboard._dashboard.areWidgetsInitialised()).toBeTruthy();
+        });
+      });
     });
 
     describe('state change', function () {

--- a/spec/api/create-dashboard.spec.js
+++ b/spec/api/create-dashboard.spec.js
@@ -112,5 +112,24 @@ describe('create-dashboard', function () {
 
       expect(this.visMock.instantiateMap).toHaveBeenCalled();
     });
+
+    describe('state change', function () {
+      beforeEach(function () {
+        spyOn(_, 'debounce').and.callFake(function (func) {
+          return function () {
+            func.apply(this, arguments);
+          };
+        });
+      });
+
+      it('should bind state changes if share_urls is true', function () {
+        spyOn(APIDashboard.prototype, 'onStateChanged').and.callThrough();
+        var callback = jasmine.createSpy('callback');
+        createDashboard(this.selectorId, this.vizJSON, { share_urls: true }, callback);
+        this.visMock.trigger('load', this.visMock);
+        this.visMock.instantiateMap.calls.argsFor(0)[0].success();
+        expect(APIDashboard.prototype.onStateChanged).toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/spec/api/create-dashboard.spec.js
+++ b/spec/api/create-dashboard.spec.js
@@ -1,4 +1,5 @@
 var Backbone = require('backbone');
+var _ = require('underscore');
 var createDashboard = require('../../src/api/create-dashboard');
 var APIDashboard = require('../../src/api/dashboard');
 var cdb = require('cartodb.js');

--- a/spec/api/dashboard.spec.js
+++ b/spec/api/dashboard.spec.js
@@ -16,6 +16,7 @@ describe('dashboard', function () {
     dashboardParameter.widgets = widgets;
     dashboardParameter.vis = new Backbone.Model();
     dashboardParameter.vis.map = new Backbone.Model();
+    dashboardParameter.areWidgetsInitialised = function () {};
 
     this.dashboard = new Dashboard(dashboardParameter);
   });
@@ -24,50 +25,16 @@ describe('dashboard', function () {
     expect(Dashboard.prototype.onDataviewsFetched).toHaveBeenCalled();
   });
 
-  describe('_widgetsAlreadyInitialized', function () {
-    beforeEach(function () {
-      this.widgetsCollection = this.dashboard._dashboard.widgets._widgetsCollection;
-      spyOn(this.widgetsCollection, 'hasInitialState');
-      spyOn(this.widgetsCollection, 'size');
-    });
-
-    describe('if there are widgets', function () {
-      beforeEach(function () {
-        this.widgetsCollection.size.and.returnValue(2);
-      });
-
-      it('should return false when widgets don\'t have initial state', function () {
-        this.widgetsCollection.hasInitialState.and.returnValue(false);
-        expect(this.dashboard._widgetsAlreadyInitialized()).toBeFalsy();
-      });
-
-      it('should return true when widgets have initial state', function () {
-        this.widgetsCollection.hasInitialState.and.returnValue(true);
-        expect(this.dashboard._widgetsAlreadyInitialized()).toBeTruthy();
-      });
-    });
-
-    describe('if there is no widgets', function () {
-      beforeEach(function () {
-        this.widgetsCollection.size.and.returnValue(0);
-      });
-
-      it('should return true when there are no widgets', function () {
-        expect(this.dashboard._widgetsAlreadyInitialized()).toBeTruthy();
-      });
-    });
-  });
-
   describe('onDataviewsFetched', function () {
     it('should trigger the callback if widgets are initialized', function () {
-      spyOn(this.dashboard, '_widgetsAlreadyInitialized').and.returnValue(true);
+      spyOn(this.dashboard._dashboard, 'areWidgetsInitialised').and.returnValue(true);
       var callback = jasmine.createSpy('callback');
       this.dashboard.onDataviewsFetched(callback);
       expect(callback).toHaveBeenCalled();
     });
 
     it('should trigger the callback when dataviews are fetched if widgets are not initialized yet', function () {
-      spyOn(this.dashboard, '_widgetsAlreadyInitialized').and.returnValue(false);
+      spyOn(this.dashboard._dashboard, 'areWidgetsInitialised').and.returnValue(false);
       var callback = jasmine.createSpy('callback');
       this.dashboard.onDataviewsFetched(callback);
       expect(callback).not.toHaveBeenCalled();

--- a/spec/api/dashboard.spec.js
+++ b/spec/api/dashboard.spec.js
@@ -31,22 +31,30 @@ describe('dashboard', function () {
       spyOn(this.widgetsCollection, 'size');
     });
 
-    it('should return false when widgets don\'t have initial state', function () {
-      this.widgetsCollection.hasInitialState.and.returnValue(false);
-      this.widgetsCollection.size.and.returnValue(2);
-      expect(this.dashboard._widgetsAlreadyInitialized()).toBeFalsy();
+    describe('if there are widgets', function () {
+      beforeEach(function () {
+        this.widgetsCollection.size.and.returnValue(2);
+      });
+
+      it('should return false when widgets don\'t have initial state', function () {
+        this.widgetsCollection.hasInitialState.and.returnValue(false);
+        expect(this.dashboard._widgetsAlreadyInitialized()).toBeFalsy();
+      });
+
+      it('should return true when widgets have initial state', function () {
+        this.widgetsCollection.hasInitialState.and.returnValue(true);
+        expect(this.dashboard._widgetsAlreadyInitialized()).toBeTruthy();
+      });
     });
 
-    it('should return true when widgets have initial state', function () {
-      this.widgetsCollection.hasInitialState.and.returnValue(true);
-      this.widgetsCollection.size.and.returnValue(1);
-      expect(this.dashboard._widgetsAlreadyInitialized()).toBeTruthy();
-    });
+    describe('if there is no widgets', function () {
+      beforeEach(function () {
+        this.widgetsCollection.size.and.returnValue(0);
+      });
 
-    it('should return true when there are no widgets', function () {
-      this.widgetsCollection.hasInitialState.and.returnValue(false);
-      this.widgetsCollection.size.and.returnValue(0);
-      expect(this.dashboard._widgetsAlreadyInitialized()).toBeTruthy();
+      it('should return true when there are no widgets', function () {
+        expect(this.dashboard._widgetsAlreadyInitialized()).toBeTruthy();
+      });
     });
   });
 

--- a/spec/api/dashboard.spec.js
+++ b/spec/api/dashboard.spec.js
@@ -2,6 +2,7 @@ var Backbone = require('backbone');
 var Dashboard = require('../../src/api/dashboard');
 var DashboardView = require('../../src/dashboard-view');
 var URLHelper = require('../../src/api/url-helper');
+
 describe('dashboard', function () {
   beforeEach(function () {
     spyOn(Dashboard.prototype, 'onDataviewsFetched').and.callThrough();
@@ -14,7 +15,7 @@ describe('dashboard', function () {
     var dashboardParameter = new Backbone.Model();
     dashboardParameter.widgets = widgets;
     dashboardParameter.vis = new Backbone.Model();
-    
+
     this.dashboard = new Dashboard(dashboardParameter);
   });
 

--- a/spec/api/dashboard.spec.js
+++ b/spec/api/dashboard.spec.js
@@ -15,12 +15,39 @@ describe('dashboard', function () {
     var dashboardParameter = new Backbone.Model();
     dashboardParameter.widgets = widgets;
     dashboardParameter.vis = new Backbone.Model();
+    dashboardParameter.vis.map = new Backbone.Model();
 
     this.dashboard = new Dashboard(dashboardParameter);
   });
 
   it('should add bind when dataviews are fetched', function () {
     expect(Dashboard.prototype.onDataviewsFetched).toHaveBeenCalled();
+  });
+
+  describe('_widgetsAlreadyInitialized', function () {
+    beforeEach(function () {
+      this.widgetsCollection = this.dashboard._dashboard.widgets._widgetsCollection;
+      spyOn(this.widgetsCollection, 'hasInitialState');
+      spyOn(this.widgetsCollection, 'size');
+    });
+
+    it('should return false when widgets don\'t have initial state', function () {
+      this.widgetsCollection.hasInitialState.and.returnValue(false);
+      this.widgetsCollection.size.and.returnValue(2);
+      expect(this.dashboard._widgetsAlreadyInitialized()).toBeFalsy();
+    });
+
+    it('should return true when widgets have initial state', function () {
+      this.widgetsCollection.hasInitialState.and.returnValue(true);
+      this.widgetsCollection.size.and.returnValue(1);
+      expect(this.dashboard._widgetsAlreadyInitialized()).toBeTruthy();
+    });
+
+    it('should return true when there are no widgets', function () {
+      this.widgetsCollection.hasInitialState.and.returnValue(false);
+      this.widgetsCollection.size.and.returnValue(0);
+      expect(this.dashboard._widgetsAlreadyInitialized()).toBeTruthy();
+    });
   });
 
   describe('onDataviewsFetched', function () {

--- a/src/api/create-dashboard.js
+++ b/src/api/create-dashboard.js
@@ -5,6 +5,7 @@ var DashboardView = require('../dashboard-view');
 var WidgetsCollection = require('../widgets/widgets-collection');
 var WidgetsService = require('../widgets-service');
 var URLHelper = require('./url-helper');
+var ReplaceState = require('./replace-state');
 
 /**
  * Translates a vizJSON v3 datastructure into a working dashboard which will be rendered in given selector.
@@ -143,9 +144,14 @@ module.exports = function (selector, vizJSON, opts, callback) {
       var dashboard = new Dashboard(dashboard);
 
       if (opts.share_urls) {
-        dashboard.onStateChanged(_.debounce(function (state, url) {
-          window.history.replaceState('Object', 'Title', url);
-        }, 500));
+        dashboard.onStateChanged(
+          _.debounce(
+            function (state, url) {
+              window.history.replaceState('Object', 'Title', url);
+            },
+            500
+          )
+        );
       }
 
       callback && callback(error, dashboard);

--- a/src/api/create-dashboard.js
+++ b/src/api/create-dashboard.js
@@ -122,7 +122,7 @@ var createDashboard = function (selector, vizJSON, opts, callback) {
         return true;
       },
       vis: vis
-    }
+    };
 
     vis.instantiateMap({
       success: function () {

--- a/src/api/create-dashboard.js
+++ b/src/api/create-dashboard.js
@@ -140,10 +140,10 @@ module.exports = function (selector, vizJSON, opts, callback) {
 
   function _load (vizJSON) {
     createDashboard(selector, vizJSON, opts, function (error, dashboard) {
-      var dashboard = new Dashboard(dashboard);
+      var _dashboard = new Dashboard(dashboard);
 
       if (opts.share_urls) {
-        dashboard.onStateChanged(
+        _dashboard.onStateChanged(
           _.debounce(
             function (state, url) {
               window.history.replaceState('Object', 'Title', url);
@@ -153,7 +153,7 @@ module.exports = function (selector, vizJSON, opts, callback) {
         );
       }
 
-      callback && callback(error, dashboard);
+      callback && callback(error, _dashboard);
     });
   }
 

--- a/src/api/create-dashboard.js
+++ b/src/api/create-dashboard.js
@@ -111,20 +111,25 @@ var createDashboard = function (selector, vizJSON, opts, callback) {
       vis.centerMapToOrigin();
     }
 
+    var callbackObj = {
+      dashboardView: dashboardView,
+      widgets: widgetsService,
+      areWidgetsInitialised: function () {
+        var widgetsCollection = widgetsService.getCollection();
+        if (widgetsCollection.size() > 0) {
+          return widgetsCollection.hasInitialState();
+        }
+        return true;
+      },
+      vis: vis
+    }
+
     vis.instantiateMap({
       success: function () {
-        callback && callback(null, {
-          dashboardView: dashboardView,
-          widgets: widgetsService,
-          vis: vis
-        });
+        callback && callback(null, callbackObj);
       },
       error: function (errorMessage) {
-        callback && callback(new Error(errorMessage), {
-          dashboardView: dashboardView,
-          widgets: widgetsService,
-          vis: vis
-        });
+        callback && callback(new Error(errorMessage), callbackObj);
       }
     });
   });

--- a/src/api/create-dashboard.js
+++ b/src/api/create-dashboard.js
@@ -5,7 +5,6 @@ var DashboardView = require('../dashboard-view');
 var WidgetsCollection = require('../widgets/widgets-collection');
 var WidgetsService = require('../widgets-service');
 var URLHelper = require('./url-helper');
-var ReplaceState = require('./replace-state');
 
 /**
  * Translates a vizJSON v3 datastructure into a working dashboard which will be rendered in given selector.

--- a/src/api/create-dashboard.js
+++ b/src/api/create-dashboard.js
@@ -140,12 +140,15 @@ module.exports = function (selector, vizJSON, opts, callback) {
 
   function _load (vizJSON) {
     createDashboard(selector, vizJSON, opts, function (error, dashboard) {
-      var dash = new Dashboard(dashboard);
-      dash.onStateChanged(_.debounce(function (state, url) {
-        window.history.replaceState('Object', 'Title', url);
-      }, 500), opts.share_urls);
+      var dashboard = new Dashboard(dashboard);
 
-      callback && callback(error, dash);
+      if (opts.share_urls) {
+        dashboard.onStateChanged(_.debounce(function (state, url) {
+          window.history.replaceState('Object', 'Title', url);
+        }, 500));
+      }
+
+      callback && callback(error, dashboard);
     });
   }
 

--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -64,7 +64,11 @@ Dashboard.prototype = {
   },
 
   _widgetsAlreadyInitialized: function () {
-    return this._dashboard.widgets._widgetsCollection.hasInitialState();
+    var widgetsCollection = this._dashboard.widgets._widgetsCollection;
+    if (widgetsCollection.size() > 0) {
+      return this._dashboard.widgets._widgetsCollection.hasInitialState();
+    }
+    return true;
   },
 
   onDataviewsFetched: function (callback) {
@@ -74,7 +78,7 @@ Dashboard.prototype = {
     } else {
       this._dashboard.vis.once('dataviewsFetched', function () {
         callback && callback();
-      }, this);
+      });
     }
   },
 

--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -44,7 +44,8 @@ Dashboard.prototype = {
     var mapState = this.getMapState();
     if (!_.isEmpty(mapState)) state.map = mapState;
 
-    var widgetsState = this._dashboard.widgets._widgetsCollection.getStates();
+    var widgetsCollection = this._dashboard.widgets.getCollection();
+    var widgetsState = widgetsCollection.getStates();
     if (!_.isEmpty(widgetsState)) state.widgets = widgetsState;
     return state;
   },
@@ -63,17 +64,9 @@ Dashboard.prototype = {
     this._dashboard.vis.mapvis.map.setBounds([state.map.ne, state.map.sw]);
   },
 
-  _widgetsAlreadyInitialized: function () {
-    var widgetsCollection = this._dashboard.widgets._widgetsCollection;
-    if (widgetsCollection.size() > 0) {
-      return this._dashboard.widgets._widgetsCollection.hasInitialState();
-    }
-    return true;
-  },
-
   onDataviewsFetched: function (callback) {
-    var areDataviewsFetched = this._widgetsAlreadyInitialized();
-    if (areDataviewsFetched) {
+    var areWidgetsInitialized = this._dashboard.areWidgetsInitialised();
+    if (areWidgetsInitialized) {
       callback && callback();
     } else {
       this._dashboard.vis.once('dataviewsFetched', function () {
@@ -89,7 +82,8 @@ Dashboard.prototype = {
   },
 
   _bindChange: function (callback) {
-    this._dashboard.widgets._widgetsCollection.bind('change', function () {
+    var widgetsCollection = this._dashboard.widgets.getCollection();
+    widgetsCollection.bind('change', function () {
       callback(this.getState(), this.getDashboardURL());
     }, this);
 

--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -7,7 +7,7 @@ function Dashboard (dashboard) {
   this.onDataviewsFetched(function () {
     dashboard.widgets._widgetsCollection.initialState();
     dashboard.widgets._widgetsCollection.each(function (m) {
-      m.applyInitialState();
+      m && m.applyInitialState && m.applyInitialState();
     });
   });
 }
@@ -63,9 +63,13 @@ Dashboard.prototype = {
     this._dashboard.vis.mapvis.map.setBounds([state.map.ne, state.map.sw]);
   },
 
+  _widgetsAlreadyInitialized: function () {
+    return this._dashboard.widgets._widgetsCollection.hasInitialState();
+  },
+
   onDataviewsFetched: function (callback) {
-    var areDataViewsFetched = this._dashboard.widgets._widgetsCollection.hasInitialState();
-    if (areDataViewsFetched) {
+    var areDataviewsFetched = this._widgetsAlreadyInitialized();
+    if (areDataviewsFetched) {
       callback && callback();
     } else {
       this._dashboard.vis.once('dataviewsFetched', function () {
@@ -75,9 +79,9 @@ Dashboard.prototype = {
   },
 
   onStateChanged: function (callback) {
-    onDataviewsFetched(function () {
+    this.onDataviewsFetched(function () {
       callback && this._bindChange(callback);
-    });
+    }.bind(this));
   },
 
   _bindChange: function (callback) {

--- a/src/widgets-service.js
+++ b/src/widgets-service.js
@@ -12,6 +12,10 @@ var WidgetsService = function (widgetsCollection, dataviews) {
   this._dataviews = dataviews;
 };
 
+WidgetsService.prototype.getCollection = function () {
+  return this._widgetsCollection;
+};
+
 WidgetsService.prototype.get = function (id) {
   return this._widgetsCollection.get(id);
 };


### PR DESCRIPTION
We have agreed a better way to "report" when a state change has happened. So any other elements can subscribe to it.

Related PR in CARTO Builder: https://github.com/CartoDB/cartodb/pull/11901#pullrequestreview-30460811