### PR TITLE
Adds dashboard#reloadMap

### DIFF
--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -28,6 +28,11 @@ Dashboard.prototype = {
     return this._dashboard.vis;
   },
 
+
+  reloadMap: function () {
+    this.getMap().reload();
+  },
+
   /**
    * @return {Array} of widgets in the dashboard
    */

--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -28,7 +28,6 @@ Dashboard.prototype = {
     return this._dashboard.vis;
   },
 
-
   reloadMap: function () {
     this.getMap().reload();
   },


### PR DESCRIPTION
Something we could use [here](https://github.com/CartoDB/cartodb/blob/866546c592549848b71e388803a0c4553c650526/lib/assets/core/javascripts/cartodb3/deep-insights-integrations.js#L722) to avoid that "train wreck"... What do you think @xavijam?  