### PR TITLE
Avoid to generate styles for autostyle if dataview has no data.

### DIFF
--- a/spec/widgets/category/category-widget-model.spec.js
+++ b/spec/widgets/category/category-widget-model.spec.js
@@ -13,6 +13,12 @@ describe('widgets/category/category-widget-model', function () {
       column: 'col'
     });
 
+    this.dataviewModel.set('data', [{
+      name: 'foo'
+    }, {
+      name: 'bar'
+    }]);
+
     spyOn(CategoryWidgetModel.prototype, '_updateColors').and.callThrough();
 
     this.widgetModel = new CategoryWidgetModel({}, {

--- a/spec/widgets/category/search-title-view.spec.js
+++ b/spec/widgets/category/search-title-view.spec.js
@@ -16,6 +16,11 @@ describe('widgets/category/search-title-view', function () {
       column: 'col'
     });
     this.dataviewModel.layer.set('initialStyle', '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: #e49115;  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}');
+    this.dataviewModel.set('data', [{
+      name: 'foo'
+    }, {
+      name: 'bar'
+    }]);
   });
 
   describe('with autoStyleEnabled as true', function () {

--- a/spec/widgets/histogram/histogram-title-view.spec.js
+++ b/spec/widgets/histogram/histogram-title-view.spec.js
@@ -18,6 +18,13 @@ describe('widgets/histogram/title-view', function () {
       column: 'a_column',
       bins: 20
     });
+
+    this.dataviewModel.set('data', [{
+      name: 'foo'
+    }, {
+      name: 'bar'
+    }]);
+
     var cartocss = '#layer {  marker-line-width: 0.5;  marker-line-color: #fcfafa;  marker-line-opacity: 1;  marker-width: 6.076923076923077;  marker-fill: ramp([something], ("#7F3C8D", "#11A579", "#3969AC", "#F2B701", "#E73F74"), ("soccer", "basketball", "baseball", "handball", "hockey"));  marker-fill-opacity: 0.9;  marker-allow-overlap: true;}';
     this.dataviewModel.layer.set({
       cartocss: cartocss,

--- a/spec/widgets/widget-model.spec.js
+++ b/spec/widgets/widget-model.spec.js
@@ -336,7 +336,7 @@ describe('widgets/widget-model', function () {
       });
     });
 
-    describe('.autoStyle', function() {
+    describe('.autoStyle', function () {
       beforeEach(function () {
         spyOn(this.model, 'isAutoStyleEnabled').and.returnValue(true);
         this.model.autoStyler = {

--- a/spec/widgets/widget-model.spec.js
+++ b/spec/widgets/widget-model.spec.js
@@ -335,6 +335,38 @@ describe('widgets/widget-model', function () {
         expect(this.model.hasColorsAutoStyle()).toBe(true);
       });
     });
+
+    describe('.autoStyle', function() {
+      beforeEach(function () {
+        spyOn(this.model, 'isAutoStyleEnabled').and.returnValue(true);
+        this.model.autoStyler = {
+          getStyle: jasmine.createSpy('getStyle')
+        };
+
+        this.model.dataviewModel.layer.set('initialStyle', 'foo');
+        this.model.dataviewModel.layer.set('cartocss', 'wadus');
+      });
+
+      it('should generate autostyle styles when dataview has data', function () {
+        this.model.dataviewModel.set('data', [{
+          name: 'foo'
+        }, {
+          name: 'bar'
+        }]);
+        this.model.autoStyle();
+
+        expect(this.model.autoStyler.getStyle).toHaveBeenCalled();
+        expect(this.model.dataviewModel.layer.get('initialStyle')).toBe('wadus');
+      });
+
+      it('should not generate autostyle styles when dataview has data', function () {
+        this.model.dataviewModel.set('data', []);
+        this.model.autoStyle();
+
+        expect(this.model.autoStyler.getStyle).not.toHaveBeenCalled();
+        expect(this.model.dataviewModel.layer.get('initialStyle')).toBe('foo');
+      });
+    });
   });
 
   describe('when autostyle option is disabled', function () {

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -124,6 +124,7 @@ module.exports = cdb.core.Model.extend({
 
   autoStyle: function () {
     if (!this.isAutoStyleEnabled()) return;
+    if (!this.dataForAutoStyle()) return;
 
     var layer = this.dataviewModel.layer;
     var initialStyle = layer.get('cartocss');
@@ -135,6 +136,10 @@ module.exports = cdb.core.Model.extend({
     var style = this.autoStyler.getStyle();
     layer.set('cartocss', style);
     this.set('autoStyle', true);
+  },
+
+  dataForAutoStyle: function () {
+    return this.dataviewModel.get('data').length > 0;
   },
 
   reapplyAutoStyle: function () {


### PR DESCRIPTION
### Context

If a widget has set the autoStyle, but the map in the instantiation phase has no data to show, the dataview linked to that widget has no data either, so the styles generated for the autoStyle are no properly formatted.

This PR is related to https://github.com/CartoDB/cartodb/issues/11838 but this is happening in production right now.

@xavijam @donflopez 