### PR TITLE
widget color changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "urijs": "1.17.1"
   },
   "devDependencies": {
+    "babel-preset-es2015": "~6.24.1",
+    "babelify": "~7.3.0",
     "browserify": "13.0.0",
     "browserify-resolutions": "1.1.0",
     "cartoassets": "CartoDB/CartoAssets#master",

--- a/spec/widgets/widget-model.spec.js
+++ b/spec/widgets/widget-model.spec.js
@@ -411,4 +411,72 @@ describe('widgets/widget-model', function () {
       });
     });
   });
+
+  describe('.getWidgetColor', function () {
+    beforeEach(function () {
+      var vis = specHelper.createDefaultVis();
+      // Use a category dataview as example
+      this.dataviewModel = vis.dataviews.createCategoryModel(vis.map.layers.first(), {
+        column: 'col'
+      });
+
+      this.model = new WidgetModel(null, {
+        dataviewModel: this.dataviewModel
+      }, {autoStyleEnabled: false});
+    });
+
+    describe('when widget_color_changed is true', function () {
+      it('should return color', function () {
+        var style = {
+          widget_style: {
+            definition:  {
+              color: {
+                fixed: '#fabada'
+              }
+            },
+            widget_color_changed: true
+          }
+        };
+        this.model.set('style', style);
+
+        expect(this.model.getWidgetColor()).toBe('#fabada');
+      });
+    });
+
+    describe('when widget_color_changed is false', function () {
+      it('should not return color', function () {
+        var style = {
+          widget_style: {
+            definition:  {
+              color: {
+                fixed: '#9DE0AD',
+              }
+            },
+            widget_color_changed: false
+          }
+        };
+        this.model.set('style', style);
+
+        expect(this.model.getWidgetColor()).toBe(false);
+      });
+
+      describe('and widget color value has changed', function () { // this is the case for existing widgets
+        it('should return color', function () {
+          var style = {
+            widget_style: {
+              definition:  {
+                color: {
+                  fixed: '#fabada',
+                  opacity: 1
+                }
+              },
+            }
+          };
+          this.model.set('style', style);
+
+          expect(this.model.getWidgetColor()).toBe('#fabada');
+        });
+      });
+    });
+  });
 });

--- a/spec/widgets/widget-model.spec.js
+++ b/spec/widgets/widget-model.spec.js
@@ -429,7 +429,7 @@ describe('widgets/widget-model', function () {
       it('should return color', function () {
         var style = {
           widget_style: {
-            definition:  {
+            definition: {
               color: {
                 fixed: '#fabada'
               }
@@ -447,9 +447,9 @@ describe('widgets/widget-model', function () {
       it('should not return color', function () {
         var style = {
           widget_style: {
-            definition:  {
+            definition: {
               color: {
-                fixed: '#9DE0AD',
+                fixed: '#9DE0AD'
               }
             },
             widget_color_changed: false
@@ -464,12 +464,12 @@ describe('widgets/widget-model', function () {
         it('should return color', function () {
           var style = {
             widget_style: {
-              definition:  {
+              definition: {
                 color: {
                   fixed: '#fabada',
                   opacity: 1
                 }
-              },
+              }
             }
           };
           this.model.set('style', style);

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -89,6 +89,7 @@ module.exports = cdb.core.Model.extend({
     var styles = this.get('style');
 
     return styles && styles.widget_style &&
+          styles.widget_style.widget_color_changed &&
           styles.widget_style.definition &&
           styles.widget_style.definition.color &&
           styles.widget_style.definition.color.fixed;

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -88,11 +88,11 @@ module.exports = cdb.core.Model.extend({
   getWidgetColor: function () {
     var styles = this.get('style');
     var widgetStyle = styles && styles.widget_style;
-    var widgetColor = widgetStyle.definition &&
+    var widgetColor = widgetStyle && widgetStyle.definition &&
       widgetStyle.definition.color &&
       widgetStyle.definition.color.fixed;
-    var widgetColorChanged = widgetStyle.widget_color_changed ||
-      !widgetStyle.widget_color_changed && widgetColor !== '#9DE0AD';
+    var widgetColorChanged = widgetStyle && widgetStyle.widget_color_changed ||
+      widgetStyle && !widgetStyle.widget_color_changed && widgetColor !== '#9DE0AD';
 
     return widgetColorChanged && widgetColor;
   },

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -87,12 +87,14 @@ module.exports = cdb.core.Model.extend({
 
   getWidgetColor: function () {
     var styles = this.get('style');
+    var widgetStyle = styles && styles.widget_style;
+    var widgetColor = widgetStyle.definition &&
+      widgetStyle.definition.color &&
+      widgetStyle.definition.color.fixed;
+    var widgetColorChanged = widgetStyle.widget_color_changed ||
+      !widgetStyle.widget_color_changed && widgetColor !== '#9DE0AD';
 
-    return styles && styles.widget_style &&
-          styles.widget_style.widget_color_changed &&
-          styles.widget_style.definition &&
-          styles.widget_style.definition.color &&
-          styles.widget_style.definition.color.fixed;
+    return widgetColorChanged && widgetColor;
   },
 
   hasColorsAutoStyle: function () {


### PR DESCRIPTION
re: https://github.com/CartoDB/cartodb/issues/12394

adding `widget_color_changed` attribute to the widget definition model style, because otherwise when selecting the category in the widget, it prevails as the widget color is persisted

I didn't quite like the hardcoded color check but I've seen it in other parts of deep insights codebase. Another workaround would be running a migration in the widgets table to add the `widget_color_changed` when the widget color won't match the default color