### PR TITLE
widgets: source: darken

### DIFF
--- a/src/widgets/category/title/search-title-template.tpl
+++ b/src/widgets/category/title/search-title-template.tpl
@@ -35,7 +35,7 @@
     <dl class="CDB-Widget-info u-tSpace">
       <div class="u-ellipsis u-flex">
         <span class="CDB-SelectorLayer-letter CDB-Text CDB-Size-small u-whiteTextColor u-rSpace u-upperCase" style="background-color: <%= sourceColor %>;"><%= sourceId %></span>
-        <p class="CDB-Text CDB-Size-small u-secondaryTextColor u-ellipsis u-flex">
+        <p class="CDB-Text CDB-Size-small u-mainTextColor u-ellipsis u-flex">
           <%= sourceType %> <span class="u-altTextColor u-lSpace u-ellipsis" title="<%= layerName %>"><%= layerName %></span>
         </p>
       </div>

--- a/src/widgets/formula/template.tpl
+++ b/src/widgets/formula/template.tpl
@@ -15,7 +15,7 @@
     <dl class="CDB-Widget-info u-tSpace">
       <div class="u-ellipsis u-flex">
         <span class="CDB-SelectorLayer-letter CDB-Text CDB-Size-small u-whiteTextColor u-rSpace u-upperCase" style="background-color: <%= sourceColor %>;"><%= sourceId %></span>
-        <p class="CDB-Text CDB-Size-small u-secondaryTextColor u-ellipsis u-flex">
+        <p class="CDB-Text CDB-Size-small u-mainTextColor u-ellipsis u-flex">
           <%= sourceType %> <span class="u-altTextColor u-lSpace u-ellipsis" title="<%= layerName %>"><%= layerName %></span>
         </p>
       </div>

--- a/src/widgets/histogram/content.tpl
+++ b/src/widgets/histogram/content.tpl
@@ -5,7 +5,7 @@
       <dl class="CDB-Widget-info u-tSpace">
         <div class="u-ellipsis u-flex">
           <span class="CDB-SelectorLayer-letter CDB-Text CDB-Size-small u-whiteTextColor u-rSpace u-upperCase" style="background-color: <%= sourceColor %>;"><%= sourceId %></span>
-          <p class="CDB-Text CDB-Size-small u-secondaryTextColor u-ellipsis u-flex">
+          <p class="CDB-Text CDB-Size-small u-mainTextColor u-ellipsis u-flex">
             <%= sourceType %> <span class="u-altTextColor u-lSpace u-ellipsis" title="<%= layerName %>"><%= layerName %></span>
           </p>
         </div>


### PR DESCRIPTION
reopening https://github.com/CartoDB/deep-insights.js/pull/552 after discussion https://github.com/CartoDB/cartodb/pull/12369#issuecomment-313396595

this just makes the analysis type darker

![screen shot 2017-07-06 at 15 28 26](https://user-images.githubusercontent.com/36676/27913835-a5d6babc-6261-11e7-98d1-a9384c1217ee.png)
