### PR TITLE
Show null if model says so.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "backbone": "1.2.3",
     "cartocolor": "4.0.0",
-    "cartodb.js": "CartoDB/cartodb.js#v4",
+    "cartodb.js": "CartoDB/cartodb.js#12477-histogram-nulls",
     "d3": "3.5.17",
     "d3-interpolate": "1.1.2",
     "jquery": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "backbone": "1.2.3",
     "cartocolor": "4.0.0",
-    "cartodb.js": "CartoDB/cartodb.js#12477-histogram-nulls",
+    "cartodb.js": "CartoDB/cartodb.js#v4",
     "d3": "3.5.17",
     "d3-interpolate": "1.1.2",
     "jquery": "2.1.4",

--- a/spec/widgets/histogram/content-view.spec.js
+++ b/spec/widgets/histogram/content-view.spec.js
@@ -262,6 +262,13 @@ describe('widgets/histogram/content-view', function () {
       expect(this.view.$('.CDB-Widget-info').length).toBe(1);
     });
 
+    it('should hide nulls if dataview model doesnt have nulls defined', function () {
+      spyOn(this.view._dataviewModel, 'hasNulls').and.returnValue(false);
+      this.widgetModel.set('show_stats', true);
+      this.view.render();
+      expect(this.view.$('.js-nulls').length).toBe(0);
+    });
+
     it('should show source when show_source is true', function () {
       expect(this.view.$('.CDB-Widget-info').length).toBe(0);
       this.widgetModel.set('show_source', true);

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -222,6 +222,7 @@ module.exports = cdb.core.View.extend({
     this._unbinds();
 
     var data = this._dataviewModel.getData();
+    var hasNulls = this._dataviewModel.hasNulls();
     var originalData = this._originalData.getData();
     var isDataEmpty = !_.size(data) && !_.size(originalData);
 
@@ -237,6 +238,7 @@ module.exports = cdb.core.View.extend({
         sourceId: sourceId,
         sourceType: analyses.title(sourceType),
         showStats: this.model.get('show_stats'),
+        showNulls: hasNulls,
         showSource: this.model.get('show_source') && letter !== '',
         itemsCount: !isDataEmpty ? data.length : '-',
         isCollapsed: !!this.model.get('collapsed'),

--- a/src/widgets/histogram/content.tpl
+++ b/src/widgets/histogram/content.tpl
@@ -13,7 +13,9 @@
     <% } %>
     <% if (showStats) { %>
       <dl class="CDB-Widget-info CDB-Text CDB-Size-small u-secondaryTextColor u-upperCase u-tSpace">
+        <% if (showNulls) { %>
         <dt class="CDB-Widget-infoCount js-nulls">0</dt><dd class="CDB-Widget-infoDescription">NULL ROWS</dd>
+        <% } %>
         <dt class="CDB-Widget-infoCount js-min">0</dt><dd class="CDB-Widget-infoDescription">MIN</dd>
         <dt class="CDB-Widget-infoCount js-avg">0</dt><dd class="CDB-Widget-infoDescription">AVG</dd>
         <dt class="CDB-Widget-infoCount js-max">0</dt><dd class="CDB-Widget-infoDescription">MAX</dd>


### PR DESCRIPTION
This PR aims to fix https://github.com/CartoDB/cartodb/issues/12477 hiding the markup when there are no nulls defined.