### PR TITLE
Add .CDB-Dashboard-hideMobile class

### DIFF
--- a/themes/scss/map/_dashboard-info.scss
+++ b/themes/scss/map/_dashboard-info.scss
@@ -234,6 +234,9 @@
   }
 }
 @media (max-width: 759px) {
+  .CDB-Dashboard-hideMobile {
+    display: none;
+  }
   .CDB-Dashboard-menu {
     display: block;
     order: 4;


### PR DESCRIPTION
Related to: https://github.com/CartoDB/support/issues/865

The problem was the menu was displayed but with `opacity: 0;`, and it sits on top of the first checkbox if the Layer Selector option is enabled.

The menu has a class called `CDB-Dashboard-hideMobile` which doesn't exist, I just added it to the `max-width: 759px` media-query.