### PR TITLE
Listen to initial state changes at timeseries view

### DIFF
--- a/spec/widgets/time-series/histogram-view.spec.js
+++ b/spec/widgets/time-series/histogram-view.spec.js
@@ -57,8 +57,9 @@ describe('widgets/time-series/histogram-view', function () {
 
   describe('.resetFilter', function () {
     it('should unset range in filter and reset filter internally', function () {
-      spyOn(this.view._rangeFilter, 'unsetRange');
+      spyOn(this.view._rangeFilter, 'unsetRange').and.callThrough();
       spyOn(this.view, '_resetFilterInDI');
+      this.view._rangeFilter.set({ min: 10, max: 50 });
 
       this.view.resetFilter();
 

--- a/src/widgets/time-series/content-view.js
+++ b/src/widgets/time-series/content-view.js
@@ -56,6 +56,7 @@ module.exports = cdb.core.View.extend({
     });
 
     this.listenTo(this._dataviewModel, 'change:data', this.render);
+    this.listenToOnce(this.model, 'change:hasInitialState', this.render);
   },
 
   _createHistogramView: function () {

--- a/src/widgets/time-series/histogram-view.js
+++ b/src/widgets/time-series/histogram-view.js
@@ -38,7 +38,6 @@ module.exports = cdb.core.View.extend({
 
   resetFilter: function () {
     this._rangeFilter.unsetRange();
-    this._resetFilterInDI();
   },
 
   _initBinds: function () {
@@ -130,7 +129,7 @@ module.exports = cdb.core.View.extend({
       max: undefined,
       lo_index: undefined,
       hi_index: undefined
-    }, { silent: true });
+    });
     this._chartView.removeSelection();
   },
 


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/issues/12576

This PR implements applying the filter in time-series widgets (no animated) when loading the map.

Related PR at `cartodb`: https://github.com/CartoDB/cartodb/pull/12577