### PR TITLE
Use width: auto when time-series is animated

### DIFF
--- a/src/widgets/time-series/placeholder.tpl
+++ b/src/widgets/time-series/placeholder.tpl
@@ -1,7 +1,7 @@
 <div class="CDB-Widget-header CDB-Widget-header--timeSeries">
   <div class="CDB-Widget-timeSeriesTimeInfo CDB-Widget-timeSeriesTimeInfo--fake"></div>
 </div>
-<div class="CDB-Widget-content CDB-Widget-content--timeSeries u-flex u-alignCenter">
+<div class="CDB-Widget-content CDB-Widget-content--<% if (hasTorqueLayer) { %>torqueTimeSeries<% } else { %>timeSeries<% } %> u-flex u-alignCenter">
   <% if (hasTorqueLayer) { %>
     <div class="CDB-Widget-timeSeriesFakeControl"></div>
   <% } %>

--- a/src/widgets/time-series/torque-histogram-view.js
+++ b/src/widgets/time-series/torque-histogram-view.js
@@ -10,7 +10,7 @@ var TorqueControlsView = require('./torque-controls-view');
  */
 module.exports = HistogramView.extend({
   className: function () {
-    return HistogramView.prototype.className + ' CDB-Widget-content CDB-Widget-content--timeSeries u-flex';
+    return HistogramView.prototype.className + ' CDB-Widget-content CDB-Widget-content--torqueTimeSeries u-flex';
   },
 
   initialize: function () {

--- a/themes/scss/widgets/_default.scss
+++ b/themes/scss/widgets/_default.scss
@@ -80,7 +80,8 @@
 }
 
 .CDB-Widget-content--histogram,
-.CDB-Widget-content--timeSeries {
+.CDB-Widget-content--timeSeries,
+.CDB-Widget-content--torqueTimeSeries, {
   touch-action: none;
   -ms-touch-action: none;
 }

--- a/themes/scss/widgets/_time-series.scss
+++ b/themes/scss/widgets/_time-series.scss
@@ -18,6 +18,7 @@
   width: $baseSize * 3;
   height: $baseSize * 3;
   margin-right: $baseSize * 3;
+  margin-top: 29px;
 }
 .CDB-Widget-timeSeriesTimeInfo {
   margin-right: $baseSize;


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/12609

Acceptance:

Create a new map with animated styles, go to the embed map in responsive mode, the chart should be inside the container and not getting out of the viewport (see issue).