### PR TITLE
Force resize when a widget is added/removed and there is a time-series

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-deep-insights.js",
-  "version": "0.0.3",
+  "version": "0.0.3-12655",
   "description": "CARTO Deep Insights JS library",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-deep-insights.js",
-  "version": "0.0.3-12655",
+  "version": "0.0.3",
   "description": "CARTO Deep Insights JS library",
   "repository": {
     "type": "git",

--- a/spec/dashboard-below-map-view.spec.js
+++ b/spec/dashboard-below-map-view.spec.js
@@ -9,7 +9,11 @@ var createFakeTimeSeriesWidgetModel = function (attrs) {
     type: 'time-series'
   });
 
-  return new Backbone.Model(attrs);
+  var Widget = Backbone.Model.extend({
+    forceResize: function () {}
+  });
+
+  return new Widget(attrs);
 };
 
 var createFakeDataviewModel = function (attrs) {
@@ -67,11 +71,13 @@ describe('dashboard-below-map-view', function () {
     });
 
     describe('_onWidgetsChange', function () {
-      it('should trigger forceResize event', function () {
-        spyOn(this.timeSeriesWidgetModelFake, 'trigger');
-        this.view._onWidgetsChange();
+      it('should call forceResize event on each widget', function () {
+        this.widgetsCollection.each(function (widget) {
+          spyOn(widget, 'forceResize');
+          this.view._onWidgetsChange();
 
-        expect(this.timeSeriesWidgetModelFake.trigger).toHaveBeenCalledWith('forceResize');
+          expect(widget.forceResize).toHaveBeenCalled();
+        }, this);
       });
 
       it('should call _toggleVisiblity function', function () {

--- a/spec/dashboard-below-map-view.spec.js
+++ b/spec/dashboard-below-map-view.spec.js
@@ -60,10 +60,10 @@ describe('dashboard-below-map-view', function () {
 
   describe('when a time-series widget is added', function () {
     beforeEach(function () {
-      this.timeSeriesWidgetModelFake = createFakeTimeSeriesWidgetModel();
-      this.timeSeriesWidgetModelFake.dataviewModel = createFakeDataviewModel();
-      this.timeSeriesWidgetModelFake.dataviewModel.layer = createFakeDataviewLayer();
-      this.widgetsCollection.add(this.timeSeriesWidgetModelFake);
+      var timeSeriesWidgetModelFake = createFakeTimeSeriesWidgetModel();
+      timeSeriesWidgetModelFake.dataviewModel = createFakeDataviewModel();
+      timeSeriesWidgetModelFake.dataviewModel.layer = createFakeDataviewLayer();
+      this.widgetsCollection.add(timeSeriesWidgetModelFake);
     });
 
     it('should render view', function () {

--- a/spec/dashboard-below-map-view.spec.js
+++ b/spec/dashboard-below-map-view.spec.js
@@ -56,14 +56,30 @@ describe('dashboard-below-map-view', function () {
 
   describe('when a time-series widget is added', function () {
     beforeEach(function () {
-      var timeSeriesWidgetModelFake = createFakeTimeSeriesWidgetModel();
-      timeSeriesWidgetModelFake.dataviewModel = createFakeDataviewModel();
-      timeSeriesWidgetModelFake.dataviewModel.layer = createFakeDataviewLayer();
-      this.widgetsCollection.add(timeSeriesWidgetModelFake);
+      this.timeSeriesWidgetModelFake = createFakeTimeSeriesWidgetModel();
+      this.timeSeriesWidgetModelFake.dataviewModel = createFakeDataviewModel();
+      this.timeSeriesWidgetModelFake.dataviewModel.layer = createFakeDataviewLayer();
+      this.widgetsCollection.add(this.timeSeriesWidgetModelFake);
     });
 
     it('should render view', function () {
       expect(this.view.$el.attr('style')).not.toContain('none');
+    });
+
+    describe('_onWidgetsChange', function () {
+      it('should trigger forceResize event', function () {
+        spyOn(this.timeSeriesWidgetModelFake, 'trigger');
+        this.view._onWidgetsChange();
+
+        expect(this.timeSeriesWidgetModelFake.trigger).toHaveBeenCalledWith('forceResize');
+      });
+
+      it('should call _toggleVisiblity function', function () {
+        spyOn(this.view, '_toggleVisiblity');
+        this.view._onWidgetsChange();
+
+        expect(this.view._toggleVisiblity).toHaveBeenCalled();
+      });
     });
   });
 

--- a/spec/widgets/histogram/chart.spec.js
+++ b/spec/widgets/histogram/chart.spec.js
@@ -57,7 +57,7 @@ describe('widgets/histogram/chart', function () {
     }.bind(this);
 
     // override default behavior of debounce, to be able to control callback
-    onWindowResizeSpy = jasmine.createSpy('_onWindowResize');
+    onWindowResizeSpy = jasmine.createSpy('onWindowResize');
     spyOn(_, 'debounce').and.callFake(function (cb) {
       onWindowResizeReal = cb;
       return onWindowResizeSpy;

--- a/spec/widgets/histogram/chart.spec.js
+++ b/spec/widgets/histogram/chart.spec.js
@@ -15,8 +15,8 @@ function flushAllD3Transitions () {
 }
 
 describe('widgets/histogram/chart', function () {
-  var onWindowResizeReal;
-  var onWindowResizeSpy;
+  var forceResizeReal;
+  var forceResizeSpy;
   var generateHandlesSpy;
   var setupBrushSpy;
   var createFormatterSpy;
@@ -57,10 +57,10 @@ describe('widgets/histogram/chart', function () {
     }.bind(this);
 
     // override default behavior of debounce, to be able to control callback
-    onWindowResizeSpy = jasmine.createSpy('onWindowResize');
+    forceResizeSpy = jasmine.createSpy('forceResize');
     spyOn(_, 'debounce').and.callFake(function (cb) {
-      onWindowResizeReal = cb;
-      return onWindowResizeSpy;
+      forceResizeReal = cb;
+      return forceResizeSpy;
     });
 
     this.widgetModel = new cdb.core.Model({
@@ -194,7 +194,7 @@ describe('widgets/histogram/chart', function () {
 
   describe('when view is resized', function () {
     beforeEach(function () {
-      onWindowResizeReal.call(this);
+      forceResizeReal.call(this);
       expect(this.view.$el.parent).toHaveBeenCalled();
     });
 

--- a/spec/widgets/time-series/histogram-view.spec.js
+++ b/spec/widgets/time-series/histogram-view.spec.js
@@ -37,11 +37,13 @@ describe('widgets/time-series/histogram-view', function () {
       this.view._dataviewModel.off();
       this.view._chartView = {
         setNormalized: function () {},
-        removeSelection: function () {}
+        removeSelection: function () {},
+        onWindowResize: function () {}
       };
       spyOn(this.view, '_onChangeData');
       spyOn(this.view, '_onNormalizedChanged');
       spyOn(this.view, '_onChangeLocalTimezone');
+      spyOn(this.view, '_onForceResize');
       spyOn(this.view, '_onFilterChanged');
 
       this.view._initBinds();
@@ -54,6 +56,9 @@ describe('widgets/time-series/histogram-view', function () {
 
       this.view._timeSeriesModel.trigger('change:local_timezone');
       expect(this.view._onChangeLocalTimezone).toHaveBeenCalled();
+
+      this.view._timeSeriesModel.trigger('forceResize');
+      expect(this.view._onForceResize).toHaveBeenCalled();
 
       this.view._rangeFilter.trigger('change');
       expect(this.view._onFilterChanged).toHaveBeenCalled();
@@ -128,6 +133,19 @@ describe('widgets/time-series/histogram-view', function () {
       this.view._onChangeLocalTimezone();
 
       expect(this.view._dataviewModel.get('localTimezone')).toBe(true);
+    });
+  });
+
+  describe('_onForceResize', function () {
+    it('should call _chartView.onWindowResize function', function () {
+      this.view._chartView = {
+        onWindowResize: function () {}
+      };
+      spyOn(this.view._chartView, 'onWindowResize');
+      this.view._initBinds();
+      this.view._onForceResize();
+
+      expect(this.view._chartView.onWindowResize).toHaveBeenCalled();
     });
   });
 

--- a/spec/widgets/time-series/histogram-view.spec.js
+++ b/spec/widgets/time-series/histogram-view.spec.js
@@ -38,7 +38,7 @@ describe('widgets/time-series/histogram-view', function () {
       this.view._chartView = {
         setNormalized: function () {},
         removeSelection: function () {},
-        onWindowResize: function () {}
+        forceResize: function () {}
       };
       spyOn(this.view, '_onChangeData');
       spyOn(this.view, '_onNormalizedChanged');
@@ -137,15 +137,12 @@ describe('widgets/time-series/histogram-view', function () {
   });
 
   describe('_onForceResize', function () {
-    it('should call _chartView.onWindowResize function', function () {
-      this.view._chartView = {
-        onWindowResize: function () {}
-      };
-      spyOn(this.view._chartView, 'onWindowResize');
+    it('should call _chartView.forceResize function', function () {
+      this.view._chartView = jasmine.createSpyObj('_chartView', ['forceResize']);
       this.view._initBinds();
       this.view._onForceResize();
 
-      expect(this.view._chartView.onWindowResize).toHaveBeenCalled();
+      expect(this.view._chartView.forceResize).toHaveBeenCalled();
     });
   });
 

--- a/spec/widgets/widget-model.spec.js
+++ b/spec/widgets/widget-model.spec.js
@@ -479,4 +479,28 @@ describe('widgets/widget-model', function () {
       });
     });
   });
+
+  describe('forceResize', function () {
+    beforeEach(function () {
+      this.model = new WidgetModel(null, {
+        dataviewModel: this.dataviewModel
+      });
+    });
+
+    it('should trigger forceResize event if it is a time-series', function () {
+      spyOn(this.model, 'trigger');
+      this.model.set('type', 'time-series');
+      this.model.forceResize();
+
+      expect(this.model.trigger).toHaveBeenCalledWith('forceResize');
+    });
+
+    it('should not trigger force Resize event if it is not a time-series', function () {
+      spyOn(this.model, 'trigger');
+      this.model.set('type', 'category');
+      this.model.forceResize();
+
+      expect(this.model.trigger).not.toHaveBeenCalledWith('forceResize');
+    });
+  });
 });

--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -32,6 +32,13 @@ Dashboard.prototype = {
     this.getMap().reload();
   },
 
+  forceResize: function () {
+    this._dashboard.widgets.getCollection()
+    .each(function (widget) {
+      widget.forceResize();
+    });
+  },
+
   /**
    * @return {Array} of widgets in the dashboard
    */

--- a/src/dashboard-below-map-view.js
+++ b/src/dashboard-below-map-view.js
@@ -74,10 +74,8 @@ module.exports = cdb.core.View.extend({
 
   _onWidgetsChange: function () {
     this._widgets.each(function (widget) {
-      if (widget.get('type') === TIME_SERIES_TYPE) {
-        widget.trigger('forceResize');
-      }
-    }, this);
+      widget.forceResize();
+    });
     this._toggleVisiblity();
   }
 });

--- a/src/dashboard-below-map-view.js
+++ b/src/dashboard-below-map-view.js
@@ -71,6 +71,11 @@ module.exports = cdb.core.View.extend({
   },
 
   _onWidgetsChange: function () {
+    this._widgets.each(function (widget) {
+      if (widget.get('type') === 'time-series') {
+        widget.trigger('forceResize');
+      }
+    }, this);
     this._toggleVisiblity();
   }
 

--- a/src/dashboard-below-map-view.js
+++ b/src/dashboard-below-map-view.js
@@ -4,6 +4,8 @@ var WidgetViewFactory = require('./widgets/widget-view-factory');
 var TimeSeriesContentView = require('./widgets/time-series/content-view');
 var TorqueTimeSeriesContentView = require('./widgets/time-series/torque-content-view');
 
+var TIME_SERIES_TYPE = 'time-series';
+
 module.exports = cdb.core.View.extend({
   className: 'CDB-Dashboard-belowMap',
 
@@ -12,7 +14,7 @@ module.exports = cdb.core.View.extend({
       {
         // same type as below, but also check if the associated layer is a a torque layer
         match: function (widgetModel) {
-          if (widgetModel.get('type') === 'time-series') {
+          if (widgetModel.get('type') === TIME_SERIES_TYPE) {
             var d = widgetModel.dataviewModel;
             return d && d.layer.get('type') === 'torque' && widgetModel.get('animated') === true;
           }
@@ -28,7 +30,7 @@ module.exports = cdb.core.View.extend({
           return attrs;
         }
       }, {
-        type: 'time-series',
+        type: TIME_SERIES_TYPE,
         createContentView: function (widgetModel) {
           return new TimeSeriesContentView({
             model: widgetModel
@@ -72,7 +74,7 @@ module.exports = cdb.core.View.extend({
 
   _onWidgetsChange: function () {
     this._widgets.each(function (widget) {
-      if (widget.get('type') === 'time-series') {
+      if (widget.get('type') === TIME_SERIES_TYPE) {
         widget.trigger('forceResize');
       }
     }, this);

--- a/src/dashboard-below-map-view.js
+++ b/src/dashboard-below-map-view.js
@@ -80,5 +80,4 @@ module.exports = cdb.core.View.extend({
     }, this);
     this._toggleVisiblity();
   }
-
 });

--- a/src/dashboard-sidebar-view.js
+++ b/src/dashboard-sidebar-view.js
@@ -52,7 +52,7 @@ module.exports = cdb.core.View.extend({
     this._widgets.bind('reset', this.render, this);
     this._widgets.bind('orderChanged', this.render, this);
     this._widgets.bind('change:collapsed', this._onWidgetUpdate, this);
-    this._widgets.bind('add remove reset', this._onUpdate, this); // have to be called _after_ any other add/remove/reset
+    this._widgets.bind('add remove reset', this._onWidgetsChange, this); // have to be called _after_ any other add/remove/reset
     this.add_related_model(this._widgets);
 
     this._resizeHandler = this._onResize.bind(this);
@@ -66,12 +66,13 @@ module.exports = cdb.core.View.extend({
     this.$el.html(template());
     this.$el.toggleClass('CDB-Widget-canvas--withMenu', this.model.get('renderMenu'));
     this._widgets.each(this._maybeRenderWidgetView, this);
-    this.$el.toggle(!_.isEmpty(this._subviews));
+    this._toggleVisiblity();
 
     this._renderScroll();
     this._renderShadows();
     this._bindScroll();
     this._initResize();
+
     return this;
   },
 
@@ -183,8 +184,12 @@ module.exports = cdb.core.View.extend({
     }
   },
 
-  _onUpdate: function () {
-    this.$el.toggle(_.size(this._subviews) > 0);
+  _toggleVisiblity: function () {
+    this.$el.toggle(!_.isEmpty(this._subviews));
+  },
+
+  _onWidgetsChange: function () {
+    this._toggleVisiblity();
   },
 
   clean: function () {

--- a/src/dashboard-view.js
+++ b/src/dashboard-view.js
@@ -1,3 +1,4 @@
+var $ = require('jquery');
 var cdb = require('cartodb.js');
 var template = require('./dashboard.tpl');
 var DashboardBelowMapView = require('./dashboard-below-map-view');
@@ -18,6 +19,8 @@ module.exports = cdb.core.View.extend({
     // TODO parent context requires some markup to be present already, but NOT the other views
     this.el.classList.add(this.className);
     this.$el.html(template());
+
+    $(window).bind('resize', this._onWindowResize.bind(this));
   },
 
   render: function () {
@@ -56,5 +59,16 @@ module.exports = cdb.core.View.extend({
     return {
       bounds: this.model.get('initialPosition').bounds
     };
+  },
+
+  _onWindowResize: function () {
+    this._widgets.each(function (widget) {
+      widget.forceResize();
+    });
+  },
+
+  clean: function () {
+    $(window).unbind('resize', this._onWindowResize);
+    cdb.core.View.prototype.clean.call(this);
   }
 });

--- a/src/dashboard-view.js
+++ b/src/dashboard-view.js
@@ -48,6 +48,7 @@ module.exports = cdb.core.View.extend({
     });
     this.addView(view);
     this.$el.append(view.render().el);
+
     return this;
   },
   getInitialMapState: function () {

--- a/src/dashboard-view.js
+++ b/src/dashboard-view.js
@@ -20,7 +20,8 @@ module.exports = cdb.core.View.extend({
     this.el.classList.add(this.className);
     this.$el.html(template());
 
-    $(window).bind('resize', this._onWindowResize.bind(this));
+    this._onWindowResize = this._onWindowResize.bind(this);
+    $(window).bind('resize', this._onWindowResize);
   },
 
   render: function () {

--- a/src/dashboard-view.js
+++ b/src/dashboard-view.js
@@ -51,6 +51,7 @@ module.exports = cdb.core.View.extend({
 
     return this;
   },
+
   getInitialMapState: function () {
     return {
       bounds: this.model.get('initialPosition').bounds

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -64,8 +64,8 @@ module.exports = cdb.core.View.extend({
     // TODO in theory there's the possiblity that the callback is called before the view is rendered in the DOM,
     //  which would lead to the view not being visible until an explicit window resize.
     //  a wasAddedToDOM event would've been nice to have
-    this._onWindowResize = _.debounce(this._resizeToParentElement.bind(this), 50);
-    $(window).bind('resize', this._onWindowResize);
+    this.onWindowResize = _.debounce(this._resizeToParentElement.bind(this), 50);
+    $(window).bind('resize', this.onWindowResize);
 
     // using tagName: 'svg' doesn't work,
     // and w/o class="" d3 won't instantiate properly
@@ -586,7 +586,7 @@ module.exports = cdb.core.View.extend({
   _setupDimensions: function () {
     this._setupScales();
     this._setupRanges();
-    this._onWindowResize();
+    this.onWindowResize();
   },
 
   _getData: function () {
@@ -1657,7 +1657,7 @@ module.exports = cdb.core.View.extend({
   },
 
   clean: function () {
-    $(window).unbind('resize', this._onWindowResize);
+    $(window).unbind('resize', this.onWindowResize);
     cdb.core.View.prototype.clean.call(this);
   }
 });

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -64,8 +64,7 @@ module.exports = cdb.core.View.extend({
     // TODO in theory there's the possiblity that the callback is called before the view is rendered in the DOM,
     //  which would lead to the view not being visible until an explicit window resize.
     //  a wasAddedToDOM event would've been nice to have
-    this.onWindowResize = _.debounce(this._resizeToParentElement.bind(this), 50);
-    $(window).bind('resize', this.onWindowResize);
+    this.forceResize = _.debounce(this._resizeToParentElement.bind(this), 50);
 
     // using tagName: 'svg' doesn't work,
     // and w/o class="" d3 won't instantiate properly
@@ -586,7 +585,7 @@ module.exports = cdb.core.View.extend({
   _setupDimensions: function () {
     this._setupScales();
     this._setupRanges();
-    this.onWindowResize();
+    this.forceResize();
   },
 
   _getData: function () {
@@ -1654,10 +1653,5 @@ module.exports = cdb.core.View.extend({
     this.updateYScale();
     this.expand(4);
     this.removeShadowBars();
-  },
-
-  clean: function () {
-    $(window).unbind('resize', this.onWindowResize);
-    cdb.core.View.prototype.clean.call(this);
   }
 });

--- a/src/widgets/time-series/histogram-view.js
+++ b/src/widgets/time-series/histogram-view.js
@@ -43,6 +43,7 @@ module.exports = cdb.core.View.extend({
     this.listenTo(this._dataviewModel, 'change:column', this.resetFilter, this);
     this.listenTo(this._timeSeriesModel, 'change:normalized', this._onNormalizedChanged);
     this.listenTo(this._timeSeriesModel, 'change:local_timezone', this._onChangeLocalTimezone);
+    this.listenTo(this._timeSeriesModel, 'forceResize', this._onForceResize);
     this.listenTo(this._rangeFilter, 'change', this._onFilterChanged);
   },
 
@@ -124,6 +125,10 @@ module.exports = cdb.core.View.extend({
 
   _onChangeLocalTimezone: function () {
     this._dataviewModel.set('localTimezone', this._timeSeriesModel.get('local_timezone'));
+  },
+
+  _onForceResize: function () {
+    this._chartView.onWindowResize();
   },
 
   _resetFilterInDI: function () {

--- a/src/widgets/time-series/histogram-view.js
+++ b/src/widgets/time-series/histogram-view.js
@@ -128,7 +128,7 @@ module.exports = cdb.core.View.extend({
   },
 
   _onForceResize: function () {
-    this._chartView.onWindowResize();
+    this._chartView.forceResize();
   },
 
   _resetFilterInDI: function () {

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -2,6 +2,8 @@ var _ = require('underscore');
 var cdb = require('cartodb.js');
 var AutoStylerFactory = require('./auto-style/factory');
 
+var TIME_SERIES_TYPE = 'time-series';
+
 /**
  * Default widget model
  *
@@ -217,5 +219,11 @@ module.exports = cdb.core.Model.extend({
       }
     }
     return state;
+  },
+
+  forceResize: function () {
+    if (this.get('type') === TIME_SERIES_TYPE) {
+      this.trigger('forceResize');
+    }
   }
 });

--- a/src/widgets/widget-model.js
+++ b/src/widgets/widget-model.js
@@ -3,6 +3,7 @@ var cdb = require('cartodb.js');
 var AutoStylerFactory = require('./auto-style/factory');
 
 var TIME_SERIES_TYPE = 'time-series';
+var HISTOGRAM_TYPE = 'histogram';
 
 /**
  * Default widget model
@@ -222,7 +223,9 @@ module.exports = cdb.core.Model.extend({
   },
 
   forceResize: function () {
-    if (this.get('type') === TIME_SERIES_TYPE) {
+    var type = this.get('type');
+    if (type === TIME_SERIES_TYPE ||
+        type === HISTOGRAM_TYPE) {
       this.trigger('forceResize');
     }
   }


### PR DESCRIPTION
The chart inside an histogram (time-series) is forced to resize when a widget is added or removed:

![force-resize-widgets](https://user-images.githubusercontent.com/2227572/29775664-4286c9e2-8c06-11e7-8045-04408000a130.gif)

I have added the public method "forceResize" to the dashboard, to enable its use from the Builder and also to avoid window.bind('resize') in the chart.
