### PR TITLE
Trigger indexes change event even if they don't change

### DIFF
--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -937,7 +937,11 @@ module.exports = cdb.core.View.extend({
           hiBarIndex = hiBarIndex + 1;
         }
       }
-      this.model.set({ lo_index: loBarIndex, hi_index: hiBarIndex });
+
+      this.model.set({ lo_index: loBarIndex, hi_index: hiBarIndex }, { silent: true });
+      // Maybe the indexes don't change, and the handlers end up stuck in the middle of the
+      // bucket because the event doesn't trigger, so let's trigger it manually
+      this.model.trigger('change:lo_index');
     }
 
     // click in non animated histogram


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/12661

The handlers where getting stuck in the middle of the buckets, debugging I found that if you moved the handler to the first half of the next bucket, it should move where it was previously, which means the same indexes, so the backbone model didn't trigger any changes which lead to the function which calculates the handler position not being called.

The proposed solution is to make the changes silent, and the trigger the event manually.