### PR TITLE
Escape HTML content in widgets source

### DIFF
--- a/spec/widgets/category/content-view.spec.js
+++ b/spec/widgets/category/content-view.spec.js
@@ -41,6 +41,13 @@ describe('widgets/category/content-view', function () {
     expect(this.view.$('.u-altTextColor').html()).toBe('&lt; &amp; &gt;&lt;h1&gt;Hello&lt;/h1&gt;');
   });
 
+  it('should render the widget when the layer name changes', function () {
+    spyOn(this.view, 'render');
+    this.view._initBinds();
+    this.dataviewModel.layer.set('layer_name', 'Hello');
+    expect(this.view.render).toHaveBeenCalled();
+  });
+
   afterEach(function () {
     this.view.clean();
   });

--- a/spec/widgets/category/content-view.spec.js
+++ b/spec/widgets/category/content-view.spec.js
@@ -12,6 +12,9 @@ describe('widgets/category/content-view', function () {
         id: 'a0'
       }
     });
+    this.dataviewModel.getLayerName = function () {
+      return '< & ><h1>Hello</h1>';
+    };
     this.model = new CategoryWidgetModel({
       title: 'Categories of something',
       hasInitialState: true
@@ -35,6 +38,7 @@ describe('widgets/category/content-view', function () {
     this.model.set('show_source', true);
     this.view.render();
     expect(this.view.$('.CDB-Widget-info').length).toBe(2);
+    expect(this.view.$('.u-altTextColor').html()).toBe('&lt; &amp; &gt;&lt;h1&gt;Hello&lt;/h1&gt;');
   });
 
   afterEach(function () {

--- a/spec/widgets/formula/content-view.spec.js
+++ b/spec/widgets/formula/content-view.spec.js
@@ -14,6 +14,9 @@ describe('widgets/formula/content-view', function () {
       },
       operation: 'avg'
     });
+    this.dataviewModel.getLayerName = function () {
+      return '< & ><h1>Hello</h1>';
+    };
     this.model = new WidgetModel({
       title: 'Max population',
       hasInitialState: true
@@ -65,5 +68,6 @@ describe('widgets/formula/content-view', function () {
     this.model.set('show_source', true);
     this.view.render();
     expect(this.view.$('.CDB-Widget-info').length).toBe(1);
+    expect(this.view.$('.u-altTextColor').html()).toBe('&lt; &amp; &gt;&lt;h1&gt;Hello&lt;/h1&gt;');
   });
 });

--- a/spec/widgets/formula/content-view.spec.js
+++ b/spec/widgets/formula/content-view.spec.js
@@ -70,4 +70,11 @@ describe('widgets/formula/content-view', function () {
     expect(this.view.$('.CDB-Widget-info').length).toBe(1);
     expect(this.view.$('.u-altTextColor').html()).toBe('&lt; &amp; &gt;&lt;h1&gt;Hello&lt;/h1&gt;');
   });
+
+  it('should render the widget when the layer name changes', function () {
+    spyOn(this.view, 'render');
+    this.view._initBinds();
+    this.dataviewModel.layer.set('layer_name', 'Hello');
+    expect(this.view.render).toHaveBeenCalled();
+  });
 });

--- a/spec/widgets/histogram/content-view.spec.js
+++ b/spec/widgets/histogram/content-view.spec.js
@@ -15,6 +15,9 @@ describe('widgets/histogram/content-view', function () {
         id: 'a0'
       }
     });
+    this.dataviewModel.getLayerName = function () {
+      return '< & ><h1>Hello</h1>';
+    };
 
     this.originalData = this.dataviewModel.getUnfilteredDataModel();
     this.originalData.set({
@@ -275,6 +278,7 @@ describe('widgets/histogram/content-view', function () {
       this.widgetModel.set('show_source', true);
       this.view.render();
       expect(this.view.$('.CDB-Widget-info').length).toBe(1);
+      expect(this.view.$('.u-altTextColor').html()).toBe('&lt; &amp; &gt;&lt;h1&gt;Hello&lt;/h1&gt;');
     });
 
     it('should collapse properly', function () {

--- a/spec/widgets/histogram/content-view.spec.js
+++ b/spec/widgets/histogram/content-view.spec.js
@@ -281,6 +281,13 @@ describe('widgets/histogram/content-view', function () {
       expect(this.view.$('.u-altTextColor').html()).toBe('&lt; &amp; &gt;&lt;h1&gt;Hello&lt;/h1&gt;');
     });
 
+    it('should render the widget when the layer name changes', function () {
+      spyOn(this.view, 'render');
+      this.view._initBinds();
+      this.dataviewModel.layer.set('layer_name', 'Hello');
+      expect(this.view.render).toHaveBeenCalled();
+    });
+
     it('should collapse properly', function () {
       expect(this.view.$('.CDB-Widget-content').length).toBe(1);
       this.widgetModel.set('collapsed', true);

--- a/spec/widgets/time-series/content-view.spec.js
+++ b/spec/widgets/time-series/content-view.spec.js
@@ -12,6 +12,10 @@ describe('widgets/time-series/content-view', function () {
         id: 'a0'
       }
     });
+    this.dataviewModel.getLayerName = function () {
+      return '< & ><h1>Hello</h1>';
+    };
+
     this.originalData = this.dataviewModel.getUnfilteredDataModel();
     this.originalData.set({
       data: [{ bin: 10 }, { bin: 3 }],
@@ -82,6 +86,7 @@ describe('widgets/time-series/content-view', function () {
         expect(this.view._headerView).toBeDefined();
         expect(this.view._dropdownView).toBeDefined();
         expect(this.view.$('.js-header .CDB-Widget-info').length).toBe(1);
+        expect(this.view.$('.u-altTextColor').html()).toBe('&lt; &amp; &gt;&lt;h1&gt;Hello&lt;/h1&gt;');
         expect(this.view.render().$el.html()).toContain('<svg');
       });
     });

--- a/spec/widgets/time-series/content-view.spec.js
+++ b/spec/widgets/time-series/content-view.spec.js
@@ -103,5 +103,12 @@ describe('widgets/time-series/content-view', function () {
       this.view.model.trigger('change:hasInitialState');
       expect(this.view.render).toHaveBeenCalled();
     });
+
+    it('should render the widget when the layer name changes', function () {
+      spyOn(this.view, 'render');
+      this.view._initBinds();
+      this.dataviewModel.layer.set('layer_name', 'Hello');
+      expect(this.view.render).toHaveBeenCalled();
+    });
   });
 });

--- a/spec/widgets/time-series/torque-content-view.spec.js
+++ b/spec/widgets/time-series/torque-content-view.spec.js
@@ -24,6 +24,10 @@ describe('widgets/time-series/torque-content-view', function () {
         id: 'a0'
       }
     });
+    this.dataviewModel.getLayerName = function () {
+      return '< & ><h1>Hello</h1>';
+    };
+
     spyOn(this.dataviewModel, 'fetch').and.callThrough();
     this.originalData = this.dataviewModel.getUnfilteredDataModel();
     this.originalData.set({
@@ -81,9 +85,17 @@ describe('widgets/time-series/torque-content-view', function () {
       expect(this.view.$('.js-torque-header').length).toBe(1);
       expect(this.view.$('.js-header .CDB-Dropdown').length).toBe(1);
       expect(this.view.$('.js-header .CDB-Widget-info').length).toBe(1);
+      expect(this.view.$('.u-altTextColor').html()).toBe('&lt; &amp; &gt;&lt;h1&gt;Hello&lt;/h1&gt;');
       expect(this.view.$('svg').length).toBe(2);
       expect(this.view._histogramView.options.displayShadowBars).toBe(true);
       expect(this.view._histogramView.options.normalized).toBe(false);
+    });
+
+    it('should render the widget when the layer name changes', function () {
+      spyOn(this.view, 'render');
+      this.view._initBinds();
+      this.dataviewModel.layer.set('layer_name', 'Hello');
+      expect(this.view.render).toHaveBeenCalled();
     });
   });
 });

--- a/src/util/escape-html.js
+++ b/src/util/escape-html.js
@@ -1,0 +1,5 @@
+var _ = require('underscore');
+
+module.exports = function escapeHTML (str) {
+  return _.escape(str);
+};

--- a/src/widgets/category/title/search-title-view.js
+++ b/src/widgets/category/title/search-title-view.js
@@ -75,6 +75,7 @@ module.exports = cdb.core.View.extend({
     this.add_related_model(this.dataviewModel.filter);
 
     this.dataviewModel.layer.bind('change:visible change:cartocss', this.render, this);
+    this.dataviewModel.layer.bind('change:layer_name', this.render, this);
     this.add_related_model(this.dataviewModel.layer);
   },
 

--- a/src/widgets/category/title/search-title-view.js
+++ b/src/widgets/category/title/search-title-view.js
@@ -6,6 +6,7 @@ var TooltipView = require('../../widget-tooltip-view');
 var template = require('./search-title-template.tpl');
 var layerColors = require('../../../util/layer-colors');
 var analyses = require('../../../data/analyses');
+var escapeHTML = require('../../../util/escape-html');
 
 /**
  *  Show category title or search any category
@@ -48,7 +49,7 @@ module.exports = cdb.core.View.extend({
         sourceType: analyses.title(sourceType),
         showSource: this.model.get('show_source') && letter !== '',
         sourceColor: sourceColor,
-        layerName: _.escape(layerName),
+        layerName: escapeHTML(layerName),
         columnName: this.dataviewModel.get('column'),
         q: this.dataviewModel.getSearchQuery(),
         isLocked: this.model.isLocked(),

--- a/src/widgets/category/title/search-title-view.js
+++ b/src/widgets/category/title/search-title-view.js
@@ -48,7 +48,7 @@ module.exports = cdb.core.View.extend({
         sourceType: analyses.title(sourceType),
         showSource: this.model.get('show_source') && letter !== '',
         sourceColor: sourceColor,
-        layerName: layerName,
+        layerName: _.escape(layerName),
         columnName: this.dataviewModel.get('column'),
         q: this.dataviewModel.getSearchQuery(),
         isLocked: this.model.isLocked(),

--- a/src/widgets/formula/content-view.js
+++ b/src/widgets/formula/content-view.js
@@ -8,6 +8,7 @@ var animationTemplate = require('./animation-template.tpl');
 var AnimateValues = require('../animate-values.js');
 var layerColors = require('../../util/layer-colors');
 var analyses = require('../../data/analyses');
+var escapeHTML = require('../../util/escape-html');
 
 /**
  * Default widget content view:
@@ -71,7 +72,7 @@ module.exports = cdb.core.View.extend({
         suffix: suffix,
         isCollapsed: isCollapsed,
         sourceColor: sourceColor,
-        layerName: _.escape(layerName)
+        layerName: escapeHTML(layerName)
       })
     );
 

--- a/src/widgets/formula/content-view.js
+++ b/src/widgets/formula/content-view.js
@@ -71,7 +71,7 @@ module.exports = cdb.core.View.extend({
         suffix: suffix,
         isCollapsed: isCollapsed,
         sourceColor: sourceColor,
-        layerName: layerName
+        layerName: _.escape(layerName)
       })
     );
 

--- a/src/widgets/formula/content-view.js
+++ b/src/widgets/formula/content-view.js
@@ -106,6 +106,9 @@ module.exports = cdb.core.View.extend({
     this.model.bind('change:title change:description change:collapsed change:prefix change:suffix', this.render, this);
     this._dataviewModel.bind('change:data', this.render, this);
     this.add_related_model(this._dataviewModel);
+
+    this._dataviewModel.layer.bind('change:layer_name', this.render, this);
+    this.add_related_model(this._dataviewModel.layer);
   },
 
   _initViews: function () {

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -87,6 +87,9 @@ module.exports = cdb.core.View.extend({
     } else {
       this.model.bind('change:hasInitialState', this._setInitialState, this);
     }
+
+    this._dataviewModel.layer.bind('change:layer_name', this.render, this);
+    this.add_related_model(this._dataviewModel.layer);
   },
 
   _setInitialState: function () {

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -243,7 +243,7 @@ module.exports = cdb.core.View.extend({
         itemsCount: !isDataEmpty ? data.length : '-',
         isCollapsed: !!this.model.get('collapsed'),
         sourceColor: sourceColor,
-        layerName: layerName
+        layerName: _.escape(layerName)
       })
     );
 

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -10,6 +10,7 @@ var AnimateValues = require('../animate-values.js');
 var animationTemplate = require('./animation-template.tpl');
 var layerColors = require('../../util/layer-colors');
 var analyses = require('../../data/analyses');
+var escapeHTML = require('../../util/escape-html');
 
 var TOOLTIP_TRIANGLE_HEIGHT = 4;
 
@@ -243,7 +244,7 @@ module.exports = cdb.core.View.extend({
         itemsCount: !isDataEmpty ? data.length : '-',
         isCollapsed: !!this.model.get('collapsed'),
         sourceColor: sourceColor,
-        layerName: _.escape(layerName)
+        layerName: escapeHTML(layerName)
       })
     );
 

--- a/src/widgets/time-series/content-view.js
+++ b/src/widgets/time-series/content-view.js
@@ -58,6 +58,9 @@ module.exports = cdb.core.View.extend({
 
     this.listenTo(this._dataviewModel, 'change:data', this.render);
     this.listenToOnce(this.model, 'change:hasInitialState', this.render);
+
+    this.listenTo(this._dataviewModel.layer, 'change:layer_name', this.render);
+    this.add_related_model(this._dataviewModel.layer);
   },
 
   _createHistogramView: function () {

--- a/src/widgets/time-series/content-view.js
+++ b/src/widgets/time-series/content-view.js
@@ -7,6 +7,7 @@ var TimeSeriesHeaderView = require('./time-series-header-view');
 var DropdownView = require('../dropdown/widget-dropdown-view');
 var layerColors = require('../../util/layer-colors');
 var analyses = require('../../data/analyses');
+var escapeHTML = require('../../util/escape-html');
 
 /**
  * Widget content view for a time-series
@@ -40,7 +41,7 @@ module.exports = cdb.core.View.extend({
         sourceType: analyses.title(sourceType),
         showSource: this.model.get('show_source') && letter !== '',
         sourceColor: sourceColor,
-        layerName: _.escape(layerName)
+        layerName: escapeHTML(layerName)
       }));
       this._createHistogramView();
       this._createHeaderView();

--- a/src/widgets/time-series/content-view.js
+++ b/src/widgets/time-series/content-view.js
@@ -40,7 +40,7 @@ module.exports = cdb.core.View.extend({
         sourceType: analyses.title(sourceType),
         showSource: this.model.get('show_source') && letter !== '',
         sourceColor: sourceColor,
-        layerName: layerName
+        layerName: _.escape(layerName)
       }));
       this._createHistogramView();
       this._createHeaderView();

--- a/src/widgets/time-series/torque-content-view.js
+++ b/src/widgets/time-series/torque-content-view.js
@@ -7,7 +7,7 @@ var TorqueHeaderView = require('./torque-header-view');
 var DropdownView = require('../dropdown/widget-dropdown-view');
 var layerColors = require('../../util/layer-colors');
 var analyses = require('../../data/analyses');
-var escapeHTML = require('../../../util/escape-html');
+var escapeHTML = require('../../util/escape-html');
 
 /**
  * Widget content view for a Torque time-series

--- a/src/widgets/time-series/torque-content-view.js
+++ b/src/widgets/time-series/torque-content-view.js
@@ -7,6 +7,7 @@ var TorqueHeaderView = require('./torque-header-view');
 var DropdownView = require('../dropdown/widget-dropdown-view');
 var layerColors = require('../../util/layer-colors');
 var analyses = require('../../data/analyses');
+var escapeHTML = require('../../../util/escape-html');
 
 /**
  * Widget content view for a Torque time-series
@@ -40,7 +41,7 @@ module.exports = cdb.core.View.extend({
         sourceType: analyses.title(sourceType),
         showSource: this.model.get('show_source') && letter !== '',
         sourceColor: sourceColor,
-        layerName: layerName
+        layerName: escapeHTML(layerName)
       }));
       this._createHeaderView();
       this._createTorqueHistogramView();
@@ -107,6 +108,9 @@ module.exports = cdb.core.View.extend({
 
     this.listenTo(this._dataviewModel, 'change:data', this.render);
     this.listenTo(this._dataviewModel, 'change:bins', this._onChangeBins);
+
+    this.listenTo(this._dataviewModel.layer, 'change:layer_name', this.render);
+    this.add_related_model(this._dataviewModel.layer);
   },
 
   _isDataEmpty: function () {


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/12322

Changes:
- Escape HTML in source layerName for all the widgets. This change prevents XSS (https://github.com/CartoDB/bug-bounty/issues/152)
- Refresh widgets when a Layer's title changes, to update its sources