### PR TITLE
Glitches for histogram charts

### DIFF
--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -290,7 +290,7 @@ module.exports = cdb.core.View.extend({
 
   _onChangeWidth: function () {
     var width = this.model.get('width');
-    this.$el.width(width);
+    this.canvas.attr('width', width);
     this.chart.attr('width', width);
     if (this.options.showOnWidthChange && width > 0) {
       this.show();
@@ -1413,8 +1413,8 @@ module.exports = cdb.core.View.extend({
       .append('rect')
       .attr('class', 'CDB-Chart-bar')
       .attr('fill', this._getFillColor.bind(this))
-      .attr('transform', function (d, i) {
-        return 'translate(' + (i * self.barWidth) + ', 0 )';
+      .attr('x', function (d, i) {
+        return i * self.barWidth;
       })
       .attr('y', self.chartHeight())
       .attr('height', 0)
@@ -1500,8 +1500,8 @@ module.exports = cdb.core.View.extend({
       .append('rect')
       .attr('class', 'CDB-Chart-bar')
       .attr('fill', this._getFillColor.bind(self))
-      .attr('transform', function (d, i) {
-        return 'translate(' + (i * self.barWidth) + ', 0)';
+      .attr('x', function (d, i) {
+        return i * self.barWidth;
       })
       .attr('y', self.chartHeight())
       .attr('height', 0)
@@ -1581,8 +1581,8 @@ module.exports = cdb.core.View.extend({
       .enter()
       .append('rect')
       .attr('class', 'CDB-Chart-shadowBar')
-      .attr('transform', function (d, i) {
-        return 'translate(' + (i * barWidth) + ', 0 )';
+      .attr('x', function (d, i) {
+        return i * barWidth;
       })
       .attr('y', function (d) {
         if (_.isEmpty(d)) {

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -1501,7 +1501,7 @@ module.exports = cdb.core.View.extend({
       .attr('class', 'CDB-Chart-bar')
       .attr('fill', this._getFillColor.bind(self))
       .attr('transform', function (d, i) {
-        return 'translate(' + (i * self.barWidth) + ', 0 )';
+        return 'translate(' + (i * self.barWidth) + ', 0)';
       })
       .attr('y', self.chartHeight())
       .attr('height', 0)

--- a/themes/scss/widgets/_chart.scss
+++ b/themes/scss/widgets/_chart.scss
@@ -40,7 +40,7 @@
 
 .CDB-Chart-bar {
   transition: fill 200ms ease;
-  shape-rendering: crispEdges;
+  shape-rendering: geometricPrecision;
 }
 
 .CDB-Chart-bar.is-highlighted {

--- a/themes/scss/widgets/_default.scss
+++ b/themes/scss/widgets/_default.scss
@@ -77,6 +77,10 @@
 
 .CDB-Chart--histogram {
   margin-top: $baseSize * 3;
+
+  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    transform: rotateZ(-0.001deg);
+  }
 }
 
 .CDB-Widget-content--histogram,


### PR DESCRIPTION
This PR improves the histograms rendering. It's related to https://github.com/CartoDB/cartodb/issues/12217. Right now, a histogram has a few issues:
- In Safari, all bars are rendered without spacing, the worst scenario occurs for time-series.
- When a user applies a zoom to the browser, the spacing is not consistent between bars. This is for all browsers.
