### PR TITLE
Fetch dataview data on zoom out

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "backbone": "1.2.3",
     "cartocolor": "4.0.0",
-    "cartodb.js": "CartoDB/cartodb.js#12945-histogram-zoom-not-working",
+    "cartodb.js": "CartoDB/cartodb.js#v4.0.0-alpha.9",
     "d3": "3.5.17",
     "d3-interpolate": "1.1.2",
     "jquery": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "backbone": "1.2.3",
     "cartocolor": "4.0.0",
-    "cartodb.js": "CartoDB/cartodb.js#4.0.0-alpha.4",
+    "cartodb.js": "CartoDB/cartodb.js#12945-histogram-zoom-not-working",
     "d3": "3.5.17",
     "d3-interpolate": "1.1.2",
     "jquery": "2.1.4",

--- a/src/widgets/histogram/content-view.js
+++ b/src/widgets/histogram/content-view.js
@@ -608,6 +608,7 @@ module.exports = cdb.core.View.extend({
       this._onZoomIn();
     } else {
       this._resetWidget();
+      this._dataviewModel.fetch();
     }
   },
 


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/issues/12945

When the user clicks on `clear` to zoom out, the data was the one of the zoomed in. We should refetch the dataviewmodel data.