### PR TITLE
Fix flex-grow in IE11

### DIFF
--- a/themes/scss/widgets/_search.scss
+++ b/themes/scss/widgets/_search.scss
@@ -13,7 +13,7 @@
   margin-right: $baseSize / 2;
 }
 .CDB-Widget-searchTextInput {
-  @include flex-grow(2);
+  @include flex(2 1 auto);
   width: 100%;
 }
 .CDB-Widget-searchApply {


### PR DESCRIPTION
Related to: https://github.com/CartoDB/support/issues/1074

When using `flex-grow(2)` the autoprefixer applied the rule `-ms-flex: 2 0 auto`, which means we're using `flex-shrink: 0`, and somehow it breaks. Using `flex-shrink: 1` which should be the initial value [according to MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink) it works.