### PR TITLE
Format timestamps with offset

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "d3-interpolate": "1.1.2",
     "jquery": "2.1.4",
     "moment": "^2.18.1",
-    "moment-timezone": "^0.5.13",
     "node-polyglot": "^2.2.2",
     "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
     "postcss": "5.0.19",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "backbone": "1.2.3",
     "cartocolor": "4.0.0",
-    "cartodb.js": "CartoDB/cartodb.js#12637-timezone-bug",
+    "cartodb.js": "CartoDB/cartodb.js#v4.0.0-alpha.23",
     "d3": "3.5.17",
     "d3-interpolate": "1.1.2",
     "jquery": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "backbone": "1.2.3",
     "cartocolor": "4.0.0",
-    "cartodb.js": "CartoDB/cartodb.js#v4.0.0-alpha.22",
+    "cartodb.js": "CartoDB/cartodb.js#12637-timezone-bug",
     "d3": "3.5.17",
     "d3-interpolate": "1.1.2",
     "jquery": "2.1.4",

--- a/spec/formatter.spec.js
+++ b/spec/formatter.spec.js
@@ -34,4 +34,13 @@ describe('formatter', function () {
     expect(formatter.timestampFactory('hour', 0)(timestamp)).toEqual('10:00 - May 6th, 2017');
     expect(formatter.timestampFactory('minute', 0)(timestamp)).toEqual('10:36 - May 6th, 2017');
   });
+
+  it('should format timestamps correctly with offset', function () {
+    function hoursToSeconds (hours) {
+      return hours * 3600;
+    }
+    expect(formatter.timestampFactory('day', hoursToSeconds(-14))(timestamp)).toEqual('May 5th, 2017');
+    expect(formatter.timestampFactory('hour', hoursToSeconds(12))(timestamp)).toEqual('22:00 - May 6th, 2017');
+    expect(formatter.timestampFactory('minute', hoursToSeconds(-5))(timestamp)).toEqual('05:36 - May 6th, 2017');
+  });
 });

--- a/spec/widgets/histogram/chart.spec.js
+++ b/spec/widgets/histogram/chart.spec.js
@@ -90,6 +90,9 @@ describe('widgets/histogram/chart', function () {
       aggregation: 'minute',
       offset: 0
     });
+    this.dataviewModel.getCurrentOffset = function () {
+      return 0;
+    };
     this.layerModel = new cdb.core.Model();
 
     this.view = new WidgetHistogramChart(({
@@ -1570,7 +1573,7 @@ describe('widgets/histogram/chart', function () {
 
         this.view._createFormatter();
 
-        expect(formatter.timestampFactory).toHaveBeenCalledWith('minute');
+        expect(formatter.timestampFactory).toHaveBeenCalledWith('minute', 0);
         expect(this.view._calculateDivisionWithByAggregation).toHaveBeenCalled();
         expect(this.view.formatter).not.toBe(formatter.formatNumber);
       });

--- a/spec/widgets/time-series/torque-time-slider-view.spec.js
+++ b/spec/widgets/time-series/torque-time-slider-view.spec.js
@@ -266,6 +266,9 @@ describe('widgets/time-series/torque-time-slider-view', function () {
       dataviewModel.getColumnType = function () {
         return 'number';
       };
+      dataviewModel.getCurrentOffset = function () {
+        return 0;
+      };
 
       view = new TorqueTimeSliderView({
         dataviewModel: dataviewModel,
@@ -290,7 +293,7 @@ describe('widgets/time-series/torque-time-slider-view', function () {
 
         view._createFormatter();
 
-        expect(formatter.timestampFactory).toHaveBeenCalledWith('minute', 0, false);
+        expect(formatter.timestampFactory).toHaveBeenCalledWith('minute', 0);
         expect(view.formatter).not.toBe(formatter.formatNumber);
       });
     });

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -1,7 +1,6 @@
 var _ = require('underscore');
 var d3 = require('d3');
 var moment = require('moment');
-require('moment-timezone');
 
 var AGGREGATION_FORMATS = {
   second: {
@@ -95,13 +94,16 @@ format.formatValue = function (value) {
   return value;
 };
 
-format.timestampFactory = function (aggregation) {
+format.timestampFactory = function (aggregation, offset) {
   return function (timestamp) {
     if (!_.has(AGGREGATION_FORMATS, aggregation)) {
       return '-';
     }
     var format = AGGREGATION_FORMATS[aggregation];
     var date = moment.unix(timestamp).utc();
+    if (_.isFinite(offset)) {
+      date.utcOffset(offset / 60);
+    }
     var formatted = date.format(format.display);
     return formatted;
   };

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -604,7 +604,7 @@ module.exports = cdb.core.View.extend({
     }
 
     if (this._dataviewModel) {
-      this.listenTo(this._dataviewModel, 'change:offset', function () {
+      this.listenTo(this._dataviewModel, 'change:offset change:localTimezone', function () {
         this.refresh();
       });
     }
@@ -1689,7 +1689,7 @@ module.exports = cdb.core.View.extend({
     this.formatter = formatter.formatNumber;
 
     if (this._isDateTimeSeries()) {
-      this.formatter = formatter.timestampFactory(this._dataviewModel.get('aggregation'));
+      this.formatter = formatter.timestampFactory(this._dataviewModel.get('aggregation'), this._dataviewModel.getCurrentOffset());
       this.options.divisionWidth = this._calculateDivisionWithByAggregation(this._dataviewModel.get('aggregation'));
     }
   },

--- a/src/widgets/time-series/time-series-header-view.js
+++ b/src/widgets/time-series/time-series-header-view.js
@@ -61,7 +61,7 @@ module.exports = cdb.core.View.extend({
     this.formatter = formatter.formatNumber;
 
     if (this._dataviewModel.getColumnType() === 'date') {
-      this.formatter = formatter.timestampFactory(this._dataviewModel.get('aggregation'), this._dataviewModel.get('offset'), this._timeSeriesModel.get('local_timezone'));
+      this.formatter = formatter.timestampFactory(this._dataviewModel.get('aggregation'), this._dataviewModel.getCurrentOffset());
     }
   },
 

--- a/src/widgets/time-series/torque-time-info-view.js
+++ b/src/widgets/time-series/torque-time-info-view.js
@@ -36,7 +36,7 @@ module.exports = cdb.core.View.extend({
         time: timeFormatter(scale(this._torqueLayerModel.get('step')))
       });
     } else if (columnType === 'date' && !isNaN(time && time.getTime())) {
-      timeFormatter = formatter.timestampFactory(this._dataviewModel.get('aggregation'), this._dataviewModel.get('offset'), this._timeSeriesModel.get('local_timezone'));
+      timeFormatter = formatter.timestampFactory(this._dataviewModel.get('aggregation'), this._dataviewModel.getCurrentOffset());
 
       html = template({
         time: timeFormatter(moment(time).unix())

--- a/src/widgets/time-series/torque-time-slider-view.js
+++ b/src/widgets/time-series/torque-time-slider-view.js
@@ -285,7 +285,7 @@ module.exports = cdb.core.View.extend({
     this.formatter = formatter.formatNumber;
 
     if (this._isDateTimeSeries()) {
-      this.formatter = formatter.timestampFactory(this._dataviewModel.get('aggregation'), this._dataviewModel.get('offset'), this._timeSeriesModel.get('local_timezone'));
+      this.formatter = formatter.timestampFactory(this._dataviewModel.get('aggregation'), this._dataviewModel.getCurrentOffset());
     }
   },
 


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/issues/13070
----

Due to changes made in https://github.com/CartoDB/cartodb.js/pull/1894 now we must format timestamps taking into account the dataview offset.