### PR TITLE
add toltips to widgets

### DIFF
--- a/src/widgets/category/title/search-title-template.tpl
+++ b/src/widgets/category/title/search-title-template.tpl
@@ -17,7 +17,7 @@
           <%- isAutoStyle ? 'is-selected' : '' %>
           <%- isAutoStyle ? 'js-cancelAutoStyle' : 'js-autoStyle' %>
           " data-tooltip="
-            <%- isAutoStyle ? 'Remove auto style' : 'Apply Auto Style' %>
+            <%- isAutoStyle ? 'Remove Auto style' : 'Apply Auto Style' %>
           ">
           <i class="CDB-IconFont CDB-IconFont-drop CDB-IconFont--small CDB-IconFont--top"></i>
         </button>

--- a/src/widgets/category/title/search-title-template.tpl
+++ b/src/widgets/category/title/search-title-template.tpl
@@ -17,12 +17,12 @@
           <%- isAutoStyle ? 'is-selected' : '' %>
           <%- isAutoStyle ? 'js-cancelAutoStyle' : 'js-autoStyle' %>
           " data-tooltip="
-            <%- isAutoStyle ? 'Remove auto style' : 'Auto style' %>
+            <%- isAutoStyle ? 'Remove auto style' : 'Apply Auto Style' %>
           ">
           <i class="CDB-IconFont CDB-IconFont-drop CDB-IconFont--small CDB-IconFont--top"></i>
         </button>
       <% } %>
-      <button class="CDB-Shape CDB-Widget-actions js-actions u-lSpace">
+      <button class="CDB-Shape CDB-Widget-actions js-actions u-lSpace" data-tooltip="More options">
         <div class="CDB-Shape-threePoints is-blue is-small">
           <div class="CDB-Shape-threePointsItem"></div>
           <div class="CDB-Shape-threePointsItem"></div>

--- a/src/widgets/category/title/search-title-view.js
+++ b/src/widgets/category/title/search-title-view.js
@@ -90,16 +90,21 @@ module.exports = cdb.core.View.extend({
       target: '.js-actions',
       container: this.$el
     });
-
     this.addView(dropdown);
 
     var colorsTooltip = new TooltipView({
       context: this.$el,
       target: '.js-colors'
     });
-
     $('body').append(colorsTooltip.render().el);
     this.addView(colorsTooltip);
+
+    var actionsTooltip = new TooltipView({
+      context: this.$el,
+      target: '.js-actions'
+    });
+    $('body').append(actionsTooltip.render().el);
+    this.addView(actionsTooltip);
   },
 
   _isAutoStyleButtonVisible: function () {

--- a/src/widgets/formula/content-view.js
+++ b/src/widgets/formula/content-view.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
 var d3 = require('d3');
+var $ = require('jquery');
 var cdb = require('cartodb.js');
 var formatter = require('../../formatter');
 var template = require('./template.tpl');
@@ -9,6 +10,7 @@ var AnimateValues = require('../animate-values.js');
 var layerColors = require('../../util/layer-colors');
 var analyses = require('../../data/analyses');
 var escapeHTML = require('../../util/escape-html');
+var TooltipView = require('../widget-tooltip-view');
 
 /**
  * Default widget content view:
@@ -118,7 +120,13 @@ module.exports = cdb.core.View.extend({
       target: '.js-actions',
       container: this.$('.js-header')
     });
-
     this.addView(dropdown);
+
+    var actionsTooltip = new TooltipView({
+      context: this.$el,
+      target: '.js-actions'
+    });
+    $('body').append(actionsTooltip.render().el);
+    this.addView(actionsTooltip);
   }
 });

--- a/src/widgets/formula/template.tpl
+++ b/src/widgets/formula/template.tpl
@@ -2,7 +2,7 @@
   <div class="CDB-Widget-title CDB-Widget-contentSpaced">
     <h3 class="CDB-Text CDB-Size-large u-ellipsis <%- isCollapsed ? 'js-value is-collapsed' : 'js-title' %>"><% if (isCollapsed) { %><%- formatedValue %><% } else { %> <%- title %><% } %></h3>
     <div class="CDB-Widget-options">
-      <button class="CDB-Shape CDB-Widget-actions js-actions">
+      <button class="CDB-Shape CDB-Widget-actions js-actions" data-tooltip="More options">
         <div class="CDB-Shape-threePoints is-blue is-small">
           <div class="CDB-Shape-threePointsItem"></div>
           <div class="CDB-Shape-threePointsItem"></div>

--- a/src/widgets/histogram/histogram-title-template.tpl
+++ b/src/widgets/histogram/histogram-title-template.tpl
@@ -5,7 +5,7 @@
       <button class="CDB-Widget-buttonIcon CDB-Widget-buttonIcon--circle js-sizes
         <%- isAutoStyle ? 'is-selected' : '' %>
         <%- isAutoStyle ? 'js-cancelAutoStyle' : 'js-autoStyle' %>
-        " data-tooltip="<%- isAutoStyle ? 'Remove auto style' : 'Apply Auto Style' %>">
+        " data-tooltip="<%- isAutoStyle ? 'Remove Auto style' : 'Apply Auto Style' %>">
         <i class="CDB-IconFont CDB-IconFont-drop CDB-IconFont--small CDB-IconFont--top"></i>
       </button>
     <% } %>

--- a/src/widgets/histogram/histogram-title-template.tpl
+++ b/src/widgets/histogram/histogram-title-template.tpl
@@ -5,11 +5,11 @@
       <button class="CDB-Widget-buttonIcon CDB-Widget-buttonIcon--circle js-sizes
         <%- isAutoStyle ? 'is-selected' : '' %>
         <%- isAutoStyle ? 'js-cancelAutoStyle' : 'js-autoStyle' %>
-        " data-tooltip="<%- isAutoStyle ? 'Remove auto style' : 'Auto style' %>">
+        " data-tooltip="<%- isAutoStyle ? 'Remove auto style' : 'Apply Auto Style' %>">
         <i class="CDB-IconFont CDB-IconFont-drop CDB-IconFont--small CDB-IconFont--top"></i>
       </button>
     <% } %>
-    <button class="CDB-Shape CDB-Widget-actions js-actions u-lSpace">
+    <button class="CDB-Shape CDB-Widget-actions js-actions u-lSpace" data-tooltip="More options">
       <div class="CDB-Shape-threePoints is-blue is-small">
         <div class="CDB-Shape-threePointsItem"></div>
         <div class="CDB-Shape-threePointsItem"></div>

--- a/src/widgets/histogram/histogram-title-view.js
+++ b/src/widgets/histogram/histogram-title-view.js
@@ -57,6 +57,13 @@ module.exports = cdb.core.View.extend({
     });
     $('body').append(sizesTooltip.render().el);
     this.addView(sizesTooltip);
+
+    var actionsTooltip = new TooltipView({
+      context: this.$el,
+      target: '.js-actions'
+    });
+    $('body').append(actionsTooltip.render().el);
+    this.addView(actionsTooltip);
   },
 
   _isAutoStyleButtonVisible: function () {

--- a/src/widgets/time-series/time-series-header-view.js
+++ b/src/widgets/time-series/time-series-header-view.js
@@ -1,9 +1,11 @@
 var cdb = require('cartodb.js');
 var d3 = require('d3');
+var $ = require('jquery');
 var template = require('./time-series-header.tpl');
 var formatter = require('../../formatter');
 var AnimateValues = require('../animate-values.js');
 var animationTemplate = require('./animation-template.tpl');
+var TooltipView = require('../widget-tooltip-view');
 
 /**
  * View to reset render range.
@@ -53,8 +55,19 @@ module.exports = cdb.core.View.extend({
     );
 
     this._animateValue();
+    this._initViews();
 
     return this;
+  },
+
+  _initViews: function () {
+    var actionsTooltip = new TooltipView({
+      context: this.$el,
+      target: '.js-actions'
+    });
+
+    $('body').append(actionsTooltip.render().el);
+    this.addView(actionsTooltip);
   },
 
   _createFormatter: function () {

--- a/src/widgets/time-series/time-series-header.tpl
+++ b/src/widgets/time-series/time-series-header.tpl
@@ -20,7 +20,7 @@
     <% if (showClearButton) { %>
       <button class="CDB-Text CDB-Size-small is-semibold u-upperCase u-actionTextColor CDB-Widget-filterButton js-clear">Clear</button>
     <% } %>
-    <button class="CDB-Shape CDB-Widget-actions js-actions u-lSpace">
+    <button class="CDB-Shape CDB-Widget-actions js-actions u-lSpace" data-tooltip="More options">
       <div class="CDB-Shape-threePoints is-blue is-small">
         <div class="CDB-Shape-threePointsItem"></div>
         <div class="CDB-Shape-threePointsItem"></div>


### PR DESCRIPTION
re: https://github.com/CartoDB/cartodb/issues/13095

- cartodb: https://github.com/CartoDB/cartodb/pull/13102
- deep-insights: https://github.com/CartoDB/deep-insights.js/pull/627

---

added "more options" tooltip and changed literals in auto style tooltips

![screen shot 2017-11-21 at 12 13 31](https://user-images.githubusercontent.com/36676/33069755-cd39a266-ceb5-11e7-8097-c3d3afd5ea5d.png)
![screen shot 2017-11-21 at 12 13 54](https://user-images.githubusercontent.com/36676/33069756-cd5e8626-ceb5-11e7-9fb1-c187f4131d37.png)
![screen shot 2017-11-21 at 12 15 30](https://user-images.githubusercontent.com/36676/33069757-cd8982b8-ceb5-11e7-9ce4-56017edf0f36.png)
![screen shot 2017-11-21 at 12 15 46](https://user-images.githubusercontent.com/36676/33069758-cda978fc-ceb5-11e7-8e0f-b2c7e979aee6.png)
![screen shot 2017-11-21 at 12 16 06](https://user-images.githubusercontent.com/36676/33069759-cddd68ba-ceb5-11e7-87af-24e4618671b0.png)
