### PR TITLE
Optimize bundle size

### DIFF
--- a/grunt-tasks/browserify.js
+++ b/grunt-tasks/browserify.js
@@ -7,7 +7,7 @@ module.exports = {
     options: {
       require: vendorDependencies.map(function(vendor) {
         return [require.resolve(vendor), { expose: vendor }];
-      }),
+      }).concat('camshaft-reference/versions/0.59.4/reference.json:./versions/0.59.4/reference.json'),
       plugin: [
         ['browserify-resolutions', vendorDependencies]
       ]

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "backbone": "1.2.3",
     "cartocolor": "4.0.0",
-    "cartodb.js": "CartoDB/cartodb.js#v4.0.0-alpha.28",
+    "cartodb.js": "CartoDB/cartodb.js#optimize-bundle-camshaft-references",
     "d3": "3.5.17",
     "d3-interpolate": "1.1.2",
     "jquery": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "backbone": "1.2.3",
     "cartocolor": "4.0.0",
-    "cartodb.js": "CartoDB/cartodb.js#optimize-bundle-camshaft-references",
+    "cartodb.js": "CartoDB/cartodb.js#v4.0.0-alpha.29",
     "d3": "3.5.17",
     "d3-interpolate": "1.1.2",
     "jquery": "2.1.4",


### PR DESCRIPTION
Related issue: https://github.com/CartoDB/cartodb.js/issues/1911

* Include explicitly the camshaft-reference file in the browersify bundle since it can not handle dynamic requires.

NOTE: when changing to webpack this is not needed.