### PR TITLE
Add missing hover and selected state colors to Widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "postcss": "5.0.19",
     "postcss-scss": "0.4.0",
     "postcss-strip-inline-comments": "0.1.5",
-    "tinycolor2": "1.4.1",
     "underscore": "1.8.3",
     "urijs": "1.17.1"
   },

--- a/src/widgets/histogram/chart.js
+++ b/src/widgets/histogram/chart.js
@@ -3,13 +3,13 @@ var _ = require('underscore');
 var d3 = require('d3');
 var d3Interpolate = require('d3-interpolate');
 var cdb = require('cartodb.js');
-var tinycolor = require('tinycolor2');
 var formatter = require('../../formatter');
 var timestampHelper = require('../../util/timestamp-helper');
 var viewportUtils = require('../../viewport-utils');
 
-var FILTERED_COLOR = '#1181FB';
+var FILTERED_COLOR = '#2E3C43';
 var UNFILTERED_COLOR = 'rgba(0, 0, 0, 0.06)';
+var HOVER_COLOR = '#82BB90';
 var TIP_RECT_HEIGHT = 17;
 var TIP_H_PADDING = 6;
 var TRIANGLE_SIDE = 14;
@@ -1441,7 +1441,7 @@ module.exports = cdb.core.View.extend({
       }
     }
 
-    return tinycolor(currentFillColor).darken(20).toString();
+    return HOVER_COLOR;
   },
 
   _updateChart: function () {

--- a/themes/scss/widgets/themes/_light.scss
+++ b/themes/scss/widgets/themes/_light.scss
@@ -87,11 +87,11 @@ $timeSliderBorder: rgba(#FFF, 1);
     background-color: $elementBkg !important;
   }
   .CDB-Widget-progressState--pattern {
-    background-color: $selected;
+    background-color: $cMainBg;
     background-image: repeating-linear-gradient(45deg, transparent 0, rgba($secondary, 0.7) 1px, transparent 2px, transparent 3px);
   }
   .CDB-Widget-progressState.is-accepted {
-    background-color: $selected;
+    background-color: $cMainBg;
   }
   .CDB-Widget-dot--navigation {
     background: $elementBkg;
@@ -120,6 +120,13 @@ $timeSliderBorder: rgba(#FFF, 1);
   .CDB-Widget-listItem--fake:after,
   .CDB-Widget-listItem--fake:before {
     background-color: $loadingBkg;
+  }
+  .CDB-Widget-listButton {
+    &:hover {
+      .CDB-Widget-progressState:not(.is-accepted) {
+        background: $cHighlightHover;
+      }
+    }
   }
   .CDB-Widget-listButton--withBorder {
     &:before {
@@ -190,6 +197,7 @@ $timeSliderBorder: rgba(#FFF, 1);
   //Charts
   .extent {
     stroke: $link;
+    color: $cMainBg;
   }
 
   .CDB-Chart-bar--timeSeries {

--- a/themes/scss/widgets/themes/_light.scss
+++ b/themes/scss/widgets/themes/_light.scss
@@ -121,11 +121,9 @@ $timeSliderBorder: rgba(#FFF, 1);
   .CDB-Widget-listItem--fake:before {
     background-color: $loadingBkg;
   }
-  .CDB-Widget-listButton {
-    &:hover {
-      .CDB-Widget-progressState:not(.is-accepted) {
-        background: $cHighlightHover;
-      }
+  .CDB-Widget-listButton:hover {
+    .CDB-Widget-progressState:not(.is-accepted) {
+      background: $cHighlightHover;
     }
   }
   .CDB-Widget-listButton--withBorder {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,6 +1274,13 @@ capture-stack-trace@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
 
+carto-zera@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/carto-zera/-/carto-zera-1.0.0.tgz#b732dbe8a756cb33db818eb53d6f6e81cd613d8b"
+  dependencies:
+    eslint "^4.10.0"
+    eslint-config-iagolast "^1.0.0"
+
 carto@cartodb/carto#master, "carto@github:cartodb/carto#master":
   version "0.15.1-cdb4"
   resolved "https://codeload.github.com/cartodb/carto/tar.gz/4dfe5361b302dda8163cd41ccbf7a9dc6898019a"
@@ -1292,15 +1299,16 @@ cartocolor@4.0.0:
   dependencies:
     colorbrewer "1.0.0"
 
-cartodb.js@CartoDB/cartodb.js#v4.0.0-alpha.34:
-  version "4.0.0-alpha.34"
-  resolved "https://codeload.github.com/CartoDB/cartodb.js/tar.gz/e66b3b55db06e4b2b3d2ce33740923bb9608caba"
+cartodb.js@CartoDB/cartodb.js#v4.0.0-beta.3:
+  version "4.0.0-beta.3"
+  resolved "https://codeload.github.com/CartoDB/cartodb.js/tar.gz/c5c8bf1be93d5362e76b30971834a436c943700f"
   dependencies:
     backbone "1.2.3"
     backbone-poller "^1.1.3"
     browserify-shim "3.8.12"
     camshaft-reference "0.34.0"
     carto cartodb/carto#master
+    carto-zera "^1.0.0"
     clip-path-polygon "0.1.12"
     d3-array "1.2.1"
     d3-format "1.2.0"
@@ -1311,9 +1319,11 @@ cartodb.js@CartoDB/cartodb.js#v4.0.0-alpha.34:
     mustache "1.1.0"
     perfect-scrollbar "git://github.com/CartoDB/perfect-scrollbar.git#master"
     postcss "5.0.19"
+    promise-polyfill "^6.1.0"
     tangram.cartodb "~0.5.7"
     torque.js CartoDB/torque#master
     underscore "1.8.3"
+    whatwg-fetch "^2.0.3"
 
 caseless@~0.11.0:
   version "0.11.0"
@@ -2165,6 +2175,10 @@ escodegen@~1.1.0:
   optionalDependencies:
     source-map "~0.1.30"
 
+eslint-config-iagolast@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-iagolast/-/eslint-config-iagolast-1.0.0.tgz#a41f4fcf150259ad5b2ada0bf91cd5fd4f06f025"
+
 eslint-config-semistandard@~11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/eslint-config-semistandard/-/eslint-config-semistandard-11.0.0.tgz#44eef7cfdfd47219e3a7b81b91b540e880bb2615"
@@ -2226,7 +2240,7 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^4.0.0:
+eslint@^4.0.0, eslint@^4.10.0:
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.13.1.tgz#0055e0014464c7eb7878caf549ef2941992b444f"
   dependencies:
@@ -5093,6 +5107,10 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
+promise-polyfill@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.1.0.tgz#dfa96943ea9c121fca4de9b5868cb39d3472e057"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -6220,10 +6238,6 @@ tiny-lr-fork@0.0.5:
     noptify "~0.0.3"
     qs "~0.5.2"
 
-tinycolor2@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
-
 title-case@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/title-case/-/title-case-1.1.2.tgz#fae4a6ae546bfa22d083a0eea910a40d12ed4f5a"
@@ -6580,6 +6594,10 @@ watchify@^3.6.1:
 weak-map@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/weak-map/-/weak-map-1.0.0.tgz#b66e56a9df0bd25a76bbf1b514db129080614a37"
+
+whatwg-fetch@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
 whet.extend@~0.9.9:
   version "0.9.9"


### PR DESCRIPTION
Related to #640 

- Deep-insights.js https://github.com/CartoDB/deep-insights.js/pull/641
- CartoDB https://github.com/CartoDB/cartodb/pull/13275

----

This PR adds the missing hover and selected state colors to Widgets.
Based on https://user-images.githubusercontent.com/14546701/32537554-50cc906e-c463-11e7-9e20-5c11a5ce4a32.png

As I removed `tinycolor` dependency and it is not used anywhere else, do you want me to remove it from the project?

### Acceptance

#### Category Widgets

- Check that `Bar Color Green with 16% black` color is applied when mouse is over any item
- Check that `Bar Color Dark` is applied when any item is selected

#### Histogram Widgets

- Check that `Bar Color Green with 16% black` color is applied when mouse is over any bar
- Check that `Bar Color Dark` is applied when there is a range selected