### PR TITLE
Display decades in time series widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "backbone": "1.2.3",
     "cartocolor": "4.0.0",
-    "cartodb.js": "CartoDB/cartodb.js#1071-decades",
+    "cartodb.js": "CartoDB/cartodb.js#v4.0.0-beta.9",
     "d3": "3.5.17",
     "d3-interpolate": "1.1.2",
     "jquery": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "backbone": "1.2.3",
     "cartocolor": "4.0.0",
-    "cartodb.js": "CartoDB/cartodb.js#v4.0.0-beta.8",
+    "cartodb.js": "CartoDB/cartodb.js#1071-decades",
     "d3": "3.5.17",
     "d3-interpolate": "1.1.2",
     "jquery": "2.1.4",

--- a/spec/formatter.spec.js
+++ b/spec/formatter.spec.js
@@ -26,6 +26,7 @@ describe('formatter', function () {
   });
 
   it('should format timestamps correctly', function () {
+    expect(formatter.timestampFactory('decade', 0)(timestamp)).toEqual('2010');
     expect(formatter.timestampFactory('year', 0)(timestamp)).toEqual('2017');
     expect(formatter.timestampFactory('quarter', 0)(timestamp)).toEqual('Q2 2017');
     expect(formatter.timestampFactory('month', 0)(timestamp)).toEqual('May 2017');

--- a/spec/formatter.spec.js
+++ b/spec/formatter.spec.js
@@ -26,7 +26,7 @@ describe('formatter', function () {
   });
 
   it('should format timestamps correctly', function () {
-    expect(formatter.timestampFactory('decade', 0)(timestamp)).toEqual('2010');
+    expect(formatter.timestampFactory('decade', 0)(timestamp)).toEqual('2017');
     expect(formatter.timestampFactory('year', 0)(timestamp)).toEqual('2017');
     expect(formatter.timestampFactory('quarter', 0)(timestamp)).toEqual('Q2 2017');
     expect(formatter.timestampFactory('month', 0)(timestamp)).toEqual('May 2017');

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -34,6 +34,10 @@ var AGGREGATION_FORMATS = {
   year: {
     display: 'YYYY',
     unit: 'y'
+  },
+  decade: {
+    display: 'YYYY',
+    unit: 'y'
   }
 };
 


### PR DESCRIPTION
Related to https://github.com/CartoDB/support/issues/1071
----

This PR shows decade labels in time series widget.